### PR TITLE
Add local development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ https://github.com/AMPLIFIER-sp-z-o-o/custom-tomcat
 
 ------------------------------------------------------------------------
 
+## Local Development
+
+For local development setup with Docker, PostgreSQL, Tomcat, and a minimal test database, see:
+
+[deploy-dev/README.md](deploy-dev/README.md)
+
+------------------------------------------------------------------------
+
 # 1. Architectural Principles
 
 ## 1.1 Offline-First by Design

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/RestAuthenticationFilter.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/RestAuthenticationFilter.java
@@ -38,7 +38,7 @@ public class RestAuthenticationFilter implements Filter {
 
             Logs.write(Logs.Level.DEBUG, "RestAuthenticationFilter -> doFilter Request URI: " + requestURI);
 
-            if("true".equals(System.getenv("AUTH_DISABLE"))){
+            if("true".equals(System.getenv("AUTH_DISABLED"))){
                 Logs.write(Logs.Level.WARN,"Authentication disabled by env: AUTH_DISABLED=true");
                 chain.doFilter(request, response);
                 return;

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/RestAuthenticationFilter.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/RestAuthenticationFilter.java
@@ -38,6 +38,12 @@ public class RestAuthenticationFilter implements Filter {
 
             Logs.write(Logs.Level.DEBUG, "RestAuthenticationFilter -> doFilter Request URI: " + requestURI);
 
+            if("true".equals(System.getenv("AUTH_DISABLE"))){
+                Logs.write(Logs.Level.WARN,"Authentication disabled by env: AUTH_DISABLED=true");
+                chain.doFilter(request, response);
+                return;
+            }
+
             boolean allowed = ALLOWED_PATHS.contains(requestURI);
             Logs.write(Logs.Level.DEBUG, "RestAuthenticationFilter -> doFilter Is path un-secure: " + (allowed ? "Yes" : "No"));
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
@@ -36,8 +36,7 @@ public class SyncAPI3 {
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     public Response SyncChangesGZip(@PathParam("tableName") String tableName, @PathParam("deviceUniqueId") String deviceUniqueId, @HeaderParam(HttpHeaders.AUTHORIZATION) String token){
         try {
-            JwtTokenValidator jwtTokenValidator = new JwtTokenValidator();
-            String subscriberUUID = jwtTokenValidator.getUserId(token);
+            String subscriberUUID = getSubscriberUUID(token);
             String schema = UserSchemaGuavaCacheUtil.getUserSchemaUsingGuava(subscriberUUID);
 
             SyncService sync = new SyncService();
@@ -62,8 +61,7 @@ public class SyncAPI3 {
         Response response = Response.ok().build();
         if(syncId.isEmpty() || syncId == null)
             return response;
-        JwtTokenValidator jwtTokenValidator = new JwtTokenValidator();
-        String subscriberUUID = jwtTokenValidator.getUserId(token);
+        String subscriberUUID = getSubscriberUUID(token);
         String schema = UserSchemaGuavaCacheUtil.getUserSchemaUsingGuava(subscriberUUID);
         SyncService sync = new SyncService();
         sync.CommitSync(syncId, schema);
@@ -74,8 +72,7 @@ public class SyncAPI3 {
     @Path("/receive-changes/{deviceUniqueId}")
     @Consumes(MediaType.APPLICATION_JSON)
     public Response ReceiveChanges(ObjectNode receivedData, @PathParam("deviceUniqueId") String deviceUniqueId, @HeaderParam(HttpHeaders.AUTHORIZATION) String token){
-        JwtTokenValidator jwtTokenValidator = new JwtTokenValidator();
-        String subscriberUUID = jwtTokenValidator.getUserId(token);
+        String subscriberUUID = getSubscriberUUID(token);
         SyncService sync = new SyncService();
         sync.ReceiveData(receivedData, UserSchemaGuavaCacheUtil.getUserSchemaUsingGuava(subscriberUUID), subscriberUUID, deviceUniqueId);
         return Response.ok().build();
@@ -86,11 +83,24 @@ public class SyncAPI3 {
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     public Response SQLitePrepopulate(@PathParam("deviceUniqueId") String deviceUniqueId, @HeaderParam(HttpHeaders.AUTHORIZATION) String token){
         JwtTokenValidator jwtTokenValidator = new JwtTokenValidator();
-        String subscriberUUID = jwtTokenValidator.getUserId(token);
+        String subscriberUUID = getSubscriberUUID(token);
         SQLitePrepopulate sqLitePrepopulate = new SQLitePrepopulate();
         File file = new File(sqLitePrepopulate.PrepopulateDatabase(subscriberUUID, deviceUniqueId));
         return Response.ok(file, MediaType.APPLICATION_OCTET_STREAM)
                 .header("Content-Disposition", "attachment; filename=\"" + file.getName() + "\"")
                 .build();
     }
+
+    /// Helpers
+    private String getSubscriberUUID(String token) {
+        JwtTokenValidator jwtTokenValidator = new JwtTokenValidator();
+        String subscriberUUID = jwtTokenValidator.getUserId(token);
+
+        if ((subscriberUUID == null || subscriberUUID.isBlank())  && "true".equals(System.getenv("AUTH_DISABLED"))) {
+            return System.getenv().get("DEV_USER_ID");
+        }
+        return subscriberUUID;
+    }
+
 }
+

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
@@ -82,7 +82,6 @@ public class SyncAPI3 {
     @Path("/prepopulate-db/{deviceUniqueId}")
     @Produces(MediaType.APPLICATION_OCTET_STREAM)
     public Response SQLitePrepopulate(@PathParam("deviceUniqueId") String deviceUniqueId, @HeaderParam(HttpHeaders.AUTHORIZATION) String token){
-        JwtTokenValidator jwtTokenValidator = new JwtTokenValidator();
         String subscriberUUID = getSubscriberUUID(token);
         SQLitePrepopulate sqLitePrepopulate = new SQLitePrepopulate();
         File file = new File(sqLitePrepopulate.PrepopulateDatabase(subscriberUUID, deviceUniqueId));
@@ -96,8 +95,8 @@ public class SyncAPI3 {
         JwtTokenValidator jwtTokenValidator = new JwtTokenValidator();
         String subscriberUUID = jwtTokenValidator.getUserId(token);
 
-        if ((subscriberUUID == null || subscriberUUID.isBlank())  && "true".equals(System.getenv("AUTH_DISABLED"))) {
-            return System.getenv().get("DEV_USER_ID");
+        if ((subscriberUUID == null || subscriberUUID.isBlank())  && "true".equalsIgnoreCase(System.getenv("AUTH_DISABLED"))) {
+            return System.getenv().getOrDefault("DEV_USER_ID", "1");
         }
         return subscriberUUID;
     }

--- a/deploy-dev/README.md
+++ b/deploy-dev/README.md
@@ -20,7 +20,8 @@ You need:
 - Docker Compose
 - curl
 
-## How to Build the WAR
+## Getting Started
+### How to Build the WAR
 
 From the repository root, run:
 
@@ -38,7 +39,7 @@ From the repository root, run:
 
   `http://localhost:8080/ampli_sync_war/ampli-sync/`
 
-  ## Start the Docker Setup
+### How to start the Docker Setup
 
   After building the WAR, start the Docker setup:
 ```bash
@@ -48,7 +49,7 @@ docker compose up --build
 
   The logs from PostgreSQL and Tomcat will be shown in the terminal.
 
-  ## Optional Startup Script
+### Optional Startup Script
 
   There is also an optional helper script:
 
@@ -57,9 +58,9 @@ docker compose up --build
   It runs both the WAR build script and then starts Docker Compose.
 
 
+## How It Works
 
-
-## Docker Setup
+### Docker Setup
 
 The Docker Compose setup starts two services:
 
@@ -80,149 +81,145 @@ PostgreSQL is exposed on the host at:
 
   `localhost:5432`
 
-  The database files are stored in the Docker volume:
+The database files are stored in the Docker volume:
 
-  `postgres-data`
+`postgres-data`
 
-  The first time the database is created, PostgreSQL runs the SQL files from:
+The first time the database is created, PostgreSQL runs the SQL files from:
 
-  `deploy-dev/docker/init-db/`
+`deploy-dev/docker/init-db/`
 
-  ### amplisync
+### `amplisync`
 
-  This service runs Tomcat and deploys the ampli-sync WAR.
+This service runs Tomcat and deploys the ampli-sync WAR.
 
-  Tomcat is exposed on the host at:
+Tomcat is exposed on the host at:
 
-  `localhost:8080`
+`localhost:8080`
 
-  The service uses the following environment variables:
-```bash
-  WORKING_DIR=/working-dir/
-  DBHOST=postgres
-  DBPORT=5432
-  DBNAME=ampli_sync_test
-  DBUSER=postgres
-  DBPASS=postgres
-  AUTH_DISABLED=true
-  DEV_USER_ID=1
-
+The service uses the following environment variables:
+```text
+WORKING_DIR=/working-dir/
+DBHOST=postgres
+DBPORT=5432
+DBNAME=ampli_sync_test
+DBUSER=postgres
+DBPASS=postgres
+AUTH_DISABLED=true
+DEV_USER_ID=1
 ```
 `AUTH_DISABLED=true` is used only in the local development setup. It disables JWT validation in the authentication filter.
 
 When auth is disabled, `DEV_USER_ID=1` is used as the user id for requests without a JWT. The test database contains this user and maps it to the `tenant_test` schema.
 
-  The Tomcat container mounts:
+The Tomcat container mounts:
 
-  deploy-dev/docker/webapps -> /usr/local/tomcat/webapps
-  deploy-dev/docker/working-dir -> /working-dir
+deploy-dev/docker/webapps -> /usr/local/tomcat/webapps 
+deploy-dev/docker/working-dir -> /working-dir
 
-  The `webapps` mount is used to deploy ROOT.war.
+The `webapps` mount is used to deploy ROOT.war.
 
-  The `working-dir` mount is used by the application to store generated files.
+The `working-dir` mount is used by the application to store generated files.
 
 
 
-  ## Database 
+### Database 
 
-  The local PostgreSQL database is initialized from:
+The local PostgreSQL database is initialized from:
 
-  `deploy-dev/docker/init-db/001-init.sql`
+`deploy-dev/docker/init-db/001-init.sql`
 
-  It creates a minimal database needed to run the sync server locally.
+It creates a minimal database needed to run the sync server locally.
 
-  It creates:
+It creates:
 
-  - `public.tenants_tenant`
-  - `public.users_customuser`
-  -  schema `tenant_test` 
-  - `tenant_test.document_headers`
+- `public.tenants_tenant`
+- `public.users_customuser`
+-  schema `tenant_test` 
+- `tenant_test.document_headers`
 
-  The test user is:
+The test user is:
+`user id: 1`
 
-  user id: 1
+This user is assigned to:
+`tenant_test`
 
-  This user is assigned to:
-
-  tenant_test
-
-  The test business table is:
-
-  tenant_test.document_headers
+The test business table is:
+`tenant_test.document_headers`
 
  
-  ## Authentication in Local Development
+### Authentication in Local Development
 
-  The normal application expects a JWT token.
+The normal application expects a JWT token.
 
-  For local development, this setup disables authentication by setting:
+For local development, this setup disables authentication by setting:
 ```bash
   AUTH_DISABLED=true
   DEV_USER_ID=1
 ```
-  This means that requests without a JWT are treated as requests from user 1.
+This means that requests without a JWT are treated as requests from user 1.
 
-  Do not use `AUTH_DISABLED=true` outside of local development.
+Do not use `AUTH_DISABLED=true` outside of local development.
 
-  # Testing
-  ## Verify the Server
+## Testing
+### Verify the Server
 
-  When the stack is running, check the health endpoint:
+When the stack is running, check the health endpoint:
 
-  curl http://localhost:8080/ampli-sync/
+curl http://localhost:8080/ampli-sync/
 
-  Expected response contains:
+Expected response contains:
 
-  Database connected
+Database connected
 
-  ## Download a Prepopulated SQLite Database
+### Download a Prepopulated SQLite Database
 
-  You can test database prepopulation with:
+You can test database prepopulation with:
 
-  `curl -OJ http://localhost:8080/ampli-sync/prepopulate-db/test-device-1`
+`curl -OJ http://localhost:8080/ampli-sync/prepopulate-db/test-device-1`
 
-  This should download a ZIP file with a SQLite database inside.
+This should download a ZIP file with a SQLite database inside.
 
-  The test-device-1 value is a device identifier. The server uses it to register or find a sync subscriber for that device.
+The test-device-1 value is a device identifier. The server uses it to register or find a sync subscriber for that device.
 
-  ## Smoke Test Suite
+### Smoke Test Suite
 
-  A simple smoke test suite is available at:
+A simple smoke test suite is available at:
 
-  `deploy-dev/docker/smoke-test.sh`
+`deploy-dev/docker/smoke-test.sh`
 
-  Run it after the Docker stack is already running:
+Run it after the Docker stack is already running:
 ```bash
   cd deploy-dev/docker
  ./smoke-test.sh
 ```
-  The smoke test checks that:
+The smoke test checks that:
 
-  - the API responds
-  - the API can connect to PostgreSQL
-  - prepopulate-db returns a non-empty ZIP file
+- the API responds
+- the API can connect to PostgreSQL
+- prepopulate-db returns a non-empty ZIP file
 
-  ## Reset the Environment
+### Reset the Environment
 
-  To stop the containers:
+To stop the containers:
 ```bash
 cd deploy-dev/docker
 docker compose down
 ```
-  To stop the containers and remove the PostgreSQL volume:
+To stop the containers and remove the PostgreSQL volume:
 ```bash
   cd deploy-dev/docker
   docker compose down -v
 ```
-  Use down -v when you want to recreate the database from init-db/001-init.sql.
+Use down -v when you want to recreate the database from init-db/001-init.sql.
 
-  ## Useful Paths
+## Useful Paths
 
-  - `deploy-dev/build-dev.sh`:              builds the WAR and copies it as ROOT.war
-  - `deploy-dev/start-dev.sh`:              builds WAR, copies it as ROOT.war, and starts the local setup
-  - `deploy-dev/docker/docker-compose.yml`: local Docker Compose setup
-  - `deploy-dev/docker/init-db/001-init.sql`: local database initialization file
-  - `deploy-dev/docker/webapps/ROOT.war`:   deployed WAR file
-  - `deploy-dev/docker/working-dir`:        application working directory
-  - `deploy-dev/docker/smoke-test.sh`:      basic smoke test suite
+- `deploy-dev/build-dev.sh`:              builds the WAR and copies it as ROOT.war
+- `deploy-dev/start-dev.sh`:              builds WAR, copies it as ROOT.war, and starts the local setup
+- `deploy-dev/docker/docker-compose.yml`: local Docker Compose setup
+- `deploy-dev/docker/init-db/001-init.sql`: local database initialization file
+- `deploy-dev/docker/webapps/ROOT.war`:   deployed WAR file
+- `deploy-dev/docker/working-dir`:        application working directory
+- `deploy-dev/docker/smoke-test.sh`:      basic smoke test suite
 

--- a/deploy-dev/README.md
+++ b/deploy-dev/README.md
@@ -1,0 +1,227 @@
+# Local Development Setup
+
+This directory contains a simple local setup for running `ampli-sync` with Docker.
+
+The goal of this setup is to make the project easy to start for development and basic testing. It runs:
+
+- PostgreSQL 16
+- Tomcat with the `ampli-sync` WAR
+- a minimal test database
+- local development auth bypass
+
+This setup is only for local development.
+
+## Prerequisites
+
+You need:
+
+- Java and Maven
+- Docker
+- Docker Compose
+- curl
+
+## How to Build the WAR
+
+From the repository root, run:
+
+  `./deploy-dev/build-dev.sh`
+
+  This script builds the Maven project and copies the generated WAR to:
+
+  `deploy-dev/docker/webapps/ROOT.war`
+
+  The WAR is deployed as ROOT.war, so the application is available at:
+
+  `http://localhost:8080/ampli-sync/`
+
+  not at:
+
+  `http://localhost:8080/ampli_sync_war/ampli-sync/`
+
+  ## Start the Docker Setup
+
+  After building the WAR, start the Docker setup:
+```bash
+cd deploy-dev/docker
+docker compose up --build
+```
+
+  The logs from PostgreSQL and Tomcat will be shown in the terminal.
+
+  ## Optional Startup Script
+
+  There is also an optional helper script:
+
+  `./deploy-dev/start-dev.sh`
+
+  It runs both the WAR build script and then starts Docker Compose.
+
+
+
+
+## Docker Setup
+
+The Docker Compose setup starts two services:
+
+- `postgres`
+- `amplisync`
+
+### `postgres`
+
+This service runs PostgreSQL 16 for local development.
+
+It creates the database with configuration:
+
+- database: `ampli_sync_test`
+- user: `postgres`
+- password: `postgres`
+
+PostgreSQL is exposed on the host at:
+
+  `localhost:5432`
+
+  The database files are stored in the Docker volume:
+
+  `postgres-data`
+
+  The first time the database is created, PostgreSQL runs the SQL files from:
+
+  `deploy-dev/docker/init-db/`
+
+  ### amplisync
+
+  This service runs Tomcat and deploys the ampli-sync WAR.
+
+  Tomcat is exposed on the host at:
+
+  `localhost:8080`
+
+  The service uses the following environment variables:
+```bash
+  WORKING_DIR=/working-dir/
+  DBHOST=postgres
+  DBPORT=5432
+  DBNAME=ampli_sync_test
+  DBUSER=postgres
+  DBPASS=postgres
+  AUTH_DISABLED=true
+  DEV_USER_ID=1
+````
+`AUTH_DISABLED=true` is used only in the local development setup. It disables JWT validation in the authentication filter.
+
+When auth is disabled, `DEV_USER_ID=1` is used as the user id for requests without a JWT. The test database contains this user and maps it to the `tenant_test` schema.
+
+  The Tomcat container mounts:
+
+  deploy-dev/docker/webapps -> /usr/local/tomcat/webapps
+  deploy-dev/docker/working-dir -> /working-dir
+
+  The `webapps` mount is used to deploy ROOT.war.
+
+  The `working-dir` mount is used by the application to store generated files.
+
+
+
+  ## Database 
+
+  The local PostgreSQL database is initialized from:
+
+  `deploy-dev/docker/init-db/001-init.sql`
+
+  It creates a minimal database needed to run the sync server locally.
+
+  It creates:
+
+  - `public.tenants_tenant`
+  - `public.users_customuser`
+  -  schema `tenant_test` 
+  - `tenant_test.document_headers`
+
+  The test user is:
+
+  user id: 1
+
+  This user is assigned to:
+
+  tenant_test
+
+  The test business table is:
+
+  tenant_test.document_headers
+
+ 
+  ## Authentication in Local Development
+
+  The normal application expects a JWT token.
+
+  For local development, this setup disables authentication by setting:
+```bash
+  AUTH_DISABLED=true
+  DEV_USER_ID=1
+```
+  This means that requests without a JWT are treated as requests from user 1.
+
+  Do not use `AUTH_DISABLED=true` outside of local development.
+
+  # Testing
+  ## Verify the Server
+
+  When the stack is running, check the health endpoint:
+
+  curl http://localhost:8080/ampli-sync/
+
+  Expected response contains:
+
+  Database connected
+
+  ## Download a Prepopulated SQLite Database
+
+  You can test database prepopulation with:
+
+  `curl -OJ http://localhost:8080/ampli-sync/prepopulate-db/test-device-1`
+
+  This should download a ZIP file with a SQLite database inside.
+
+  The test-device-1 value is a device identifier. The server uses it to register or find a sync subscriber for that device.
+
+  ## Smoke Test Suite
+
+  A simple smoke test suite is available at:
+
+  `deploy-dev/docker/smoke-test.sh`
+
+  Run it after the Docker stack is already running:
+```bash
+  cd deploy-dev/docker
+ ./smoke-test.sh
+```
+  The smoke test checks that:
+
+  - the API responds
+  - the API can connect to PostgreSQL
+  - prepopulate-db returns a non-empty ZIP file
+
+  ## Reset the Environment
+
+  To stop the containers:
+```bash
+cd deploy-dev/docker
+docker compose down
+```
+  To stop the containers and remove the PostgreSQL volume:
+```bash
+  cd deploy-dev/docker
+  docker compose down -v
+```
+  Use down -v when you want to recreate the database from init-db/001-init.sql.
+
+  ## Useful Paths
+
+  - `deploy-dev/build-dev.sh`:              builds the WAR and copies it as ROOT.war
+  - `deploy-dev/start-dev.sh`:              builds WAR, copies it as ROOT.war, and starts the local setup
+  - `deploy-dev/docker/docker-compose.yml`: local Docker Compose setup
+  - `deploy-dev/docker/init-db/001-init.sql`: local database initialization file
+  - `deploy-dev/docker/webapps/ROOT.war`:   deployed WAR file
+  - `deploy-dev/docker/working-dir`:        application working directory
+  - `deploy-dev/docker/smoke-test.sh`:      basic smoke test suite
+

--- a/deploy-dev/README.md
+++ b/deploy-dev/README.md
@@ -106,7 +106,8 @@ PostgreSQL is exposed on the host at:
   DBPASS=postgres
   AUTH_DISABLED=true
   DEV_USER_ID=1
-````
+
+```
 `AUTH_DISABLED=true` is used only in the local development setup. It disables JWT validation in the authentication filter.
 
 When auth is disabled, `DEV_USER_ID=1` is used as the user id for requests without a JWT. The test database contains this user and maps it to the `tenant_test` schema.

--- a/deploy-dev/build-dev.sh
+++ b/deploy-dev/build-dev.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+cd ampli-sync
+mvn package war:exploded
+cd ..
+cp ampli-sync/target/ampli-sync-3.war deploy-dev/docker/webapps/ROOT.war
+
+echo "Built WAR and copied it to deploy-dev/docker/webapps/ROOT.war"

--- a/deploy-dev/docker/.gitignore
+++ b/deploy-dev/docker/.gitignore
@@ -1,0 +1,3 @@
+webapps/
+working-dir/
+*.war

--- a/deploy-dev/docker/Dockerfile-tomcat11
+++ b/deploy-dev/docker/Dockerfile-tomcat11
@@ -1,0 +1,11 @@
+FROM tomcat:11.0-jdk21-temurin
+
+RUN rm -rf /usr/local/tomcat/webapps/*
+ENV JAVA_OPTS="\
+  -XX:+UseG1GC \
+  -Dfile.encoding=UTF-8 \
+"
+
+EXPOSE 8080
+
+CMD ["catalina.sh", "run"]

--- a/deploy-dev/docker/docker-compose.yml
+++ b/deploy-dev/docker/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       JWT_SHARED_SECRET: changeme
       LOG_LEVEL: 4
       PACKAGE_SIZE: 5000
+      AUTH_DISABLED: "true"
+      DEV_USER_ID: "1"
     volumes:
       - ./webapps:/usr/local/tomcat/webapps
       - ./working-dir:/working-dir

--- a/deploy-dev/docker/docker-compose.yml
+++ b/deploy-dev/docker/docker-compose.yml
@@ -11,6 +11,12 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./init-db:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres -d ampli_sync_test" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
   amplisync:
     build:
       context: .
@@ -34,6 +40,7 @@ services:
       - ./webapps:/usr/local/tomcat/webapps
       - ./working-dir:/working-dir
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
 volumes:
   postgres-data:

--- a/deploy-dev/docker/docker-compose.yml
+++ b/deploy-dev/docker/docker-compose.yml
@@ -1,4 +1,16 @@
 services:
+  postgres:
+    image: postgres:16
+    container_name: ampli-sync-postgres-dev
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: ampli_sync_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+      - ./init-db:/docker-entrypoint-initdb.d
   amplisync:
     build:
       context: .
@@ -10,7 +22,7 @@ services:
       WORKING_DIR: "/working-dir/"
       DBUSER: postgres
       DBPASS: postgres
-      DBHOST: host.docker.internal
+      DBHOST: postgres
       DBPORT: 5432
       DBNAME: ampli_sync_test
       JWT_SHARED_SECRET: changeme
@@ -19,3 +31,7 @@ services:
     volumes:
       - ./webapps:/usr/local/tomcat/webapps
       - ./working-dir:/working-dir
+    depends_on:
+      - postgres
+volumes:
+  postgres-data:

--- a/deploy-dev/docker/docker-compose.yml
+++ b/deploy-dev/docker/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  amplisync:
+    build:
+      context: .
+      dockerfile: Dockerfile-tomcat11
+    container_name: ampli-sync-dev
+    ports:
+      - "8080:8080"
+    environment:
+      WORKING_DIR: "/working-dir/"
+      DBUSER: postgres
+      DBPASS: postgres
+      DBHOST: host.docker.internal
+      DBPORT: 5432
+      DBNAME: ampli_sync_test
+      JWT_SHARED_SECRET: changeme
+      LOG_LEVEL: 4
+      PACKAGE_SIZE: 5000
+    volumes:
+      - ./webapps:/usr/local/tomcat/webapps
+      - ./working-dir:/working-dir

--- a/deploy-dev/docker/init-db/001-init.sql
+++ b/deploy-dev/docker/init-db/001-init.sql
@@ -1,0 +1,33 @@
+create extension if not exists "uuid-ossp";
+
+create table if not exists public.tenants_tenant (
+    id bigint primary key,
+    schema_name varchar(100) not null
+    );
+
+create table if not exists public.users_customuser (
+    id bigint primary key,
+    default_tenant_id bigint not null references public.tenants_tenant(id)
+);
+
+create schema if not exists tenant_test;
+
+insert into public.tenants_tenant (id, schema_name)
+values (1, 'tenant_test')
+on conflict (id) do nothing;
+
+insert into public.users_customuser (id, default_tenant_id)
+values (1, 1)
+on conflict (id) do nothing;
+
+create table if not exists tenant_test.document_headers (
+    id uuid primary key default uuid_generate_v4(),
+    title text not null,
+    amount numeric,
+    created_at timestamp default current_timestamp
+);
+
+insert into tenant_test.document_headers (title, amount)
+values
+('Test document 1', 100),
+('Test document 2', 200);

--- a/deploy-dev/docker/smoke-test.sh
+++ b/deploy-dev/docker/smoke-test.sh
@@ -1,19 +1,19 @@
-  #!/usr/bin/env bash
-  set -euo pipefail
+#!/usr/bin/env bash
+set -euo pipefail
 
-  BASE_URL="http://localhost:8080/ampli-sync"
-  DEVICE_ID="smoke-device-1"
-  OUT_DIR="/tmp/ampli-sync-smoke"
+BASE_URL="http://localhost:8080/ampli-sync"
+DEVICE_ID="smoke-device-1"
+OUT_DIR="/tmp/ampli-sync-smoke"
 
-  mkdir -p "$OUT_DIR"
+mkdir -p "$OUT_DIR"
 
-  echo "Checking API health:"
-  curl -fsS "$BASE_URL/" | grep "Database connected"
+echo "Checking API health:"
+curl -fsS "$BASE_URL/" | grep "Database connected"
 
-  echo "Downloading SQLite database with prepopulate endpoint:"
-  curl -fsSLo "$OUT_DIR/database.zip" "$BASE_URL/prepopulate-db/$DEVICE_ID"
+echo "Downloading SQLite database with prepopulate endpoint:"
+curl -fsSLo "$OUT_DIR/database.zip" "$BASE_URL/prepopulate-db/$DEVICE_ID"
 
-  test -s "$OUT_DIR/database.zip"
+test -s "$OUT_DIR/database.zip"
 
-  echo "Smoke test passed."
-  echo "Downloaded database archive: $OUT_DIR/database.zip"
+echo "Smoke test passed."
+echo "Downloaded database archive: $OUT_DIR/database.zip"

--- a/deploy-dev/docker/smoke-test.sh
+++ b/deploy-dev/docker/smoke-test.sh
@@ -1,0 +1,19 @@
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  BASE_URL="http://localhost:8080/ampli-sync"
+  DEVICE_ID="smoke-device-1"
+  OUT_DIR="/tmp/ampli-sync-smoke"
+
+  mkdir -p "$OUT_DIR"
+
+  echo "Checking API health:"
+  curl -fsS "$BASE_URL/" | grep "Database connected"
+
+  echo "Downloading SQLite database with prepopulate endpoint:"
+  curl -fsSLo "$OUT_DIR/database.zip" "$BASE_URL/prepopulate-db/$DEVICE_ID"
+
+  test -s "$OUT_DIR/database.zip"
+
+  echo "Smoke test passed."
+  echo "Downloaded database archive: $OUT_DIR/database.zip"

--- a/deploy-dev/start-dev.sh
+++ b/deploy-dev/start-dev.sh
@@ -1,0 +1,10 @@
+ #!/usr/bin/env bash
+  set -euo pipefail
+
+  cd "$(dirname "$0")/.."
+
+  ./deploy-dev/build-dev.sh
+
+  cd deploy-dev/docker
+   docker compose up --build
+d


### PR DESCRIPTION
# Summary

  - adds a local Docker Compose setup with Tomcat and PostgreSQL
  - adds minimal local database  
  - adds local development auth bypass with envs `AUTH_DISABLED` and `DEV_USER_ID`
  - adds helper scripts for building the WAR and running the smoke test suite
  -  adds local development guide in `deploy-dev/README.md`
  - shows the local development guide from main README

#  Verification

  - `./deploy-dev/build-dev.sh` - generate WAR and copy it to docker/weabapps directory as ROOT.war
  - `cd deploy-dev/docker + docker compose up --build`
  - `./smoke-test.sh` - run test healthcheck,prepopulate-db endpoints, and downloads database file

