### PR TITLE
Setup/remote debug

### DIFF
--- a/deploy-dev/README.md
+++ b/deploy-dev/README.md
@@ -25,29 +25,29 @@ You need:
 
 From the repository root, run:
 
-  `./deploy-dev/build-dev.sh`
+`./deploy-dev/build-dev.sh`
 
-  This script builds the Maven project and copies the generated WAR to:
+This script builds the Maven project and copies the generated WAR to:
 
-  `deploy-dev/docker/webapps/ROOT.war`
+`deploy-dev/docker/webapps/ROOT.war`
 
-  The WAR is deployed as ROOT.war, so the application is available at:
+The WAR is deployed as ROOT.war, so the application is available at:
 
-  `http://localhost:8080/ampli-sync/`
+`http://localhost:8080/ampli-sync/`
 
-  not at:
+not at:
 
-  `http://localhost:8080/ampli_sync_war/ampli-sync/`
+`http://localhost:8080/ampli_sync_war/ampli-sync/`
 
 ### How to start the Docker Setup
 
-  After building the WAR, start the Docker setup:
+After building the WAR, start the Docker setup:
 ```bash
 cd deploy-dev/docker
 docker compose up --build
 ```
 
-  The logs from PostgreSQL and Tomcat will be shown in the terminal.
+The logs from PostgreSQL and Tomcat will be shown in the terminal.
 
 ### Remote Debugging
 
@@ -55,13 +55,13 @@ The local Docker setup can also run Tomcat with remote debugging.
 
 First build the WAR:
 
-`/deploy-dev/build-dev.sh`
+`./deploy-dev/build-dev.sh`
 
 Then start Docker Compose with the extra debug file that overrides base compose file:
 ```bash
 cd deploy-dev/docker
 docker compose -f docker-compose.yml -f docker-compose.debug.yml up --build
-````
+```
 This starts the application normally on:
 
 `http://localhost:8080/ampli-sync/`
@@ -88,7 +88,7 @@ You can test the debugger for example by setting a breakpoint in helper method:
 
 and then call:
 
-`curl  http://localhost:8080/ampli-sync/prepopulate-db/test-device-1`
+`curl http://localhost:8080/ampli-sync/prepopulate-db/test-device-1`
 
 If IntelliJ stops on breakpoint, remote debugging is working.
 

--- a/deploy-dev/README.md
+++ b/deploy-dev/README.md
@@ -49,13 +49,57 @@ docker compose up --build
 
   The logs from PostgreSQL and Tomcat will be shown in the terminal.
 
+### Remote Debugging
+
+The local Docker setup can also run Tomcat with remote debugging.
+
+First build the WAR:
+
+`/deploy-dev/build-dev.sh`
+
+Then start Docker Compose with the extra debug file that overrides base compose file:
+```bash
+cd deploy-dev/docker
+docker compose -f docker-compose.yml -f docker-compose.debug.yml up --build
+````
+This starts the application normally on:
+
+`http://localhost:8080/ampli-sync/`
+
+and exposes the debug port on:
+
+`localhost:5005`
+
+In IntelliJ IDEA, create a new configuration:
+
+`Run -> Edit Configurations -> Add New Configuration -> Remote JVM Debug`
+
+Use:
+
+`Host: localhost`
+
+`Port: 5005`
+
+Start this configuration with Debug, not Run.
+
+You can test the debugger for example by setting a breakpoint in helper method:
+
+`SyncAPI3.getSubscriberUUID`
+
+and then call:
+
+`curl  http://localhost:8080/ampli-sync/prepopulate-db/test-device-1`
+
+If IntelliJ stops on breakpoint, remote debugging is working.
+
+
 ### Optional Startup Script
 
-  There is also an optional helper script:
+There is also an optional helper script:
 
-  `./deploy-dev/start-dev.sh`
+`./deploy-dev/start-dev.sh`
 
-  It runs both the WAR build script and then starts Docker Compose.
+It runs both the WAR build script and then starts Docker Compose.
 
 
 ## How It Works

--- a/deploy-dev/docker/docker-compose.debug.yml
+++ b/deploy-dev/docker/docker-compose.debug.yml
@@ -1,0 +1,8 @@
+services:
+  amplisync:
+    ports:
+      - "5005:5005"
+    environment:
+      JPDA_ADDRESS: "*:5005"
+      JPDA_TRANSPORT: dt_socket
+    command: ["catalina.sh", "jpda", "run"]


### PR DESCRIPTION
# Summary

- adds override: docker compose  file, to run Tomcat with remote debugging 
- port exposed: 5005
- remote debugging included in deploy-dev/README.md

# Verification
`./deploy-dev/build-dev.sh`

`cd deploy-dev/docker`

`docker compose -f docker-compose.yml -f docker-compose.debug.yml up --build`

Set up intellij remote debug: localhost:5005 and set up a breakpoint, preferably in helper method in SyncAPI3 at the bottom

Send: `curl http://localhost:8080/ampli-sync/prepopulate-db/test-device-1`


