### PR TITLE
Dependencies update

### DIFF
--- a/ampli-sync/pom.xml
+++ b/ampli-sync/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.40.8</version>
+                <version>2.46.9</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>5.1.0</version>
+            <version>7.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>
@@ -93,12 +93,12 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.4.0-jre</version>
+            <version>33.6.0-jre</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.18.0</version>
+            <version>2.22.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>4.5.0</version>
+            <version>4.5.2</version>
         </dependency>
 
         <!-- Testing -->
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.13.2</version>
+            <version>2.14.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.41.2.2</version>
+            <version>3.53.2.0</version>
         </dependency>
     </dependencies>
     <build>
@@ -157,7 +157,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>true</failOnMissingWebXml>
                 </configuration>

--- a/ampli-sync/pom.xml
+++ b/ampli-sync/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>7.0.2</version>
+            <version>5.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.flywaydb</groupId>


### PR DESCRIPTION
## Updated:

  - AWS SDK BOM: `2.40.8` -> `2.46.9`
  - java-jwt: `4.5.0` -> `4.5.2`
  - gson: `2.13.2` -> `2.14.0`
  - guava: `33.4.0-jre` -> `33.6.0-jre`
  - commons-io: `2.18.0` -> `2.22.0`
  - sqlite-jdbc: `3.41.2.2` -> `3.53.2.0`
  - maven-war-plugin: `3.4.0` -> `3.5.1`


  ## Unchanged:

  - Jackson/Jersey/Jakarta: Jersey and Jakarta are major updates probably requiring migration
  - Flyway: newer versions require Jackson 3 dependencies
  - HikariCP: latest version = major update
  - JUnit: latest version = major update and project doesn't use many tests
  - jakarta.servlet-api: already has latest stable version
  - commons-compress: already has latest stable version

  ## Problem:
  
  Also, there is an existing Jackson version conflict on `origin/master`: the WAR contains both Jackson `2.20.1` modules, and `2.18.0` modules, probably from Jersey.
