### PR TITLE
Feature/dev client bootstrap

### DIFF
--- a/tools/dev-client/README.md
+++ b/tools/dev-client/README.md
@@ -39,4 +39,18 @@ Idea: follow the same sync flow as the React Native example, but in a simpler fo
 - `SqliteDatabase` handles local SQLite access.
 - Push payload builder - work in progress
 
+## Test - Manual check
 
+With the local Docker backend running, I run `DevClientRunner`.
+
+Output:
+
+```text
+API[bb924e2] OK! Database connected!
+demo_customers exists: true
+Demo customers:
+0b8e9b8e-0fb5-4f2d-8d4c-3c57e7dc8e47 | North Coast Shop | hello@northcoast.example | Gdansk
+5e7b16b0-0c2f-4e9d-9f74-2d7a8f4c0b21 | Acme Retail | orders@acme.example | Warsaw
+8fb5f9c7-9929-4f87-8fcb-19f2092f0a5d | Green Market | contact@greenmarket.example | Poznan
+ad6510d7-c44f-4cfa-94c3-3f56a32a4c89 | Metro Office | office@metro.example | Krakow
+```

--- a/tools/dev-client/README.md
+++ b/tools/dev-client/README.md
@@ -1,0 +1,42 @@
+# AMPLI-SYNC Dev Client
+
+Java client for checking the ampli-sync backend synchronization flow without using the mobile client
+
+Idea: follow the same sync flow as the React Native example, but in a simpler form for manual checks and regression tests.
+
+## Implemented so far
+
+- backend health check,
+- download SQLite database archive from `prepopulate-db`,
+- unpack downloaded database archive,
+- open local SQLite database,
+- check that demo tables exist, print content in runner
+
+## Planned scope
+
+
+1. Add local SQLite operations: insert, update, delete
+
+2. Build payload with changes from local SQLite, following the logic:
+   - rows with `rowid is null` as inserts,
+   - rows with `mergeupdate > 0 and rowid is not null` as updates,
+   - rows from `mergedelete` as deletes.
+
+3. Send local changes to backend:
+   - call `receive-changes/`,
+   - verify that pushed data appears in PostgreSQL.
+
+4. Pull changes from backend:
+   - call sync endpoint for selected tables,
+   - apply returned changes to local SQLite.
+
+5. Use this client in full integration and regression tests:
+ 
+
+## Structure
+
+- `SyncDevClient` handles  communication with the ampli-sync backend.
+- `SqliteDatabase` handles local SQLite access.
+- Push payload builder - work in progress
+
+

--- a/tools/dev-client/pom.xml
+++ b/tools/dev-client/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <maven.compiler.source>21</maven.compiler.source>
-        <maven.compiler.target>21</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/tools/dev-client/pom.xml
+++ b/tools/dev-client/pom.xml
@@ -14,4 +14,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.53.2.0</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/tools/dev-client/pom.xml
+++ b/tools/dev-client/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.ampliapps.amplisync</groupId>
+    <artifactId>dev-client</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -14,6 +14,9 @@ public class DevClientRunner {
 
         try (SqliteDatabase database = SqliteDatabase.open(databasePath)) {
             System.out.println("demo_customers exists: " + database.tableExists("demo_customers"));
+            System.out.println("Demo customers:");
+            database.printDemoCustomers();
+
         }
     }
 }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -1,0 +1,19 @@
+package com.ampliapps.amplisync.devclient;
+
+import java.nio.file.Path;
+
+public class DevClientRunner {
+    public static void main(String[] args) {
+        SyncDevClient client = new SyncDevClient("http://localhost:8080/ampli-sync/");
+
+        System.out.println(client.healthCheck());
+
+        Path outputDirectory = Path.of("/tmp/ampli-sync-dev-client");
+        Path archivePath = client.downloadPrepopulatedDatabaseArchive("dev-client-device-1", outputDirectory);
+        Path databasePath = client.unpackDatabaseArchive(archivePath, outputDirectory);
+
+        try (SqliteDatabase database = SqliteDatabase.open(databasePath)) {
+            System.out.println("demo_customers exists: " + database.tableExists("demo_customers"));
+        }
+    }
+}

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -1,0 +1,53 @@
+package com.ampliapps.amplisync.devclient;
+
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class SqliteDatabase implements AutoCloseable {
+    private final Connection connection;
+
+    private SqliteDatabase(Connection connection) {
+        this.connection = connection;
+    }
+
+    public static SqliteDatabase open(Path databasePath) {
+        try {
+            Connection connection = DriverManager.getConnection("jdbc:sqlite:" + databasePath);
+            return new SqliteDatabase(connection);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to open SQLite database: " + databasePath, e);
+        }
+    }
+
+    public boolean tableExists(String tableName) {
+        String sql = """
+                  select 1
+                  from sqlite_master
+                  where type = 'table'
+                    and name = ?
+                  """;
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, tableName);
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to check SQLite table: " + tableName, e);
+        }
+    }
+
+    @Override
+    public void close() {
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to close SQLite database", e);
+        }
+    }
+}

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -6,6 +6,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 public class SqliteDatabase implements AutoCloseable {
     private final Connection connection;
@@ -41,6 +42,22 @@ public class SqliteDatabase implements AutoCloseable {
             throw new IllegalStateException("Failed to check SQLite table: " + tableName, e);
         }
     }
+
+    public void printDemoCustomers() {
+        String sql = "select id, name, email, city from demo_customers";
+
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            while (resultSet.next()) {
+                System.out.println(
+                        resultSet.getString("id") + " | " + resultSet.getString("name") + " | " + resultSet.getString("email") + " | " + resultSet.getString("city")
+                );
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to print demo customers", e);
+        }
+    }
+
 
     @Override
     public void close() {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -5,6 +5,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public class SyncDevClient {
     private static final String DEV_AUTH_HEADER = "Bearer dev-local-token";
@@ -51,6 +53,37 @@ public class SyncDevClient {
         return syncBaseUrl.endsWith("/") ? syncBaseUrl : syncBaseUrl + "/";
     }
 
+    public Path downloadPrepopulatedDatabaseArchive(String deviceId, Path outputDirectory) {
+        if (deviceId == null  || deviceId.isBlank()) {
+            throw new IllegalArgumentException("deviceId can't be empty");
+        }
+
+        try {
+            Files.createDirectories(outputDirectory);
+
+            Path archivePath = outputDirectory.resolve("database.zip");
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(syncBaseUrl + "prepopulate-db/" + deviceId))
+                    .header("Authorization", DEV_AUTH_HEADER)
+                    .GET()
+                    .build();
+
+            HttpResponse<Path> response = httpClient.send(request, HttpResponse.BodyHandlers.ofFile(archivePath));
+
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IllegalStateException("Prepopulate database failed with status: " + response.statusCode());
+            }
+
+            return archivePath;
+        } catch (IOException e) {
+            throw new IllegalStateException("Prepopulate database request failed", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Prepopulate database request was interrupted", e);
+
+        }
+    }
     /*
      - call backend health endpoint
      - download, unpack sqlite database from prepopulate-db

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -1,0 +1,13 @@
+package com.ampliapps.amplisync.devclient;
+
+public class SyncDevClient {
+    /*
+     - call backend health endpoint
+     - download, unpack sqlite database from prepopulate-db
+     - open sqlite database
+     - perform local insert/update/delete operations
+     - build payload from local SQLite, like in rn client
+     - send local changes to the backend
+     - pull changes from the backend
+     */
+}

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -7,7 +7,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 public class SyncDevClient {
-    private static final String DEV_AUTH_HEADER = "dev-local-token";
+    private static final String DEV_AUTH_HEADER = "Bearer dev-local-token";
 
     private final String syncBaseUrl;
     private final HttpClient httpClient;

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -7,6 +7,9 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 public class SyncDevClient {
     private static final String DEV_AUTH_HEADER = "Bearer dev-local-token";
@@ -54,7 +57,7 @@ public class SyncDevClient {
     }
 
     public Path downloadPrepopulatedDatabaseArchive(String deviceId, Path outputDirectory) {
-        if (deviceId == null  || deviceId.isBlank()) {
+        if (deviceId == null || deviceId.isBlank()) {
             throw new IllegalArgumentException("deviceId can't be empty");
         }
 
@@ -81,9 +84,45 @@ public class SyncDevClient {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Prepopulate database request was interrupted", e);
-
         }
     }
+    
+    public Path unpackDatabaseArchive(Path archivePath, Path outputDirectory) {
+        try {
+            Files.createDirectories(outputDirectory);
+            unzip(archivePath, outputDirectory);
+
+            Path databasePath = outputDirectory.resolve("amperflow.db");
+
+            if (!Files.exists(databasePath)) {
+                throw new IllegalStateException("Prepopulated database was not found in archive: " + databasePath);
+            }
+
+            return databasePath;
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to unpack prepopulated database archive", e);
+        }
+    }
+
+    private static void unzip(Path archivePath, Path outputDirectory) throws IOException {
+        try (ZipInputStream zipInputStream = new ZipInputStream(Files.newInputStream(archivePath))) {
+            ZipEntry entry;
+
+            while ((entry = zipInputStream.getNextEntry()) != null) {
+                Path targetPath = outputDirectory.resolve(entry.getName());
+
+                if (entry.isDirectory()) {
+                    Files.createDirectories(targetPath);
+                } else {
+                    Files.createDirectories(targetPath.getParent());
+                    Files.copy(zipInputStream, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                }
+
+                zipInputStream.closeEntry();
+            }
+        }
+    }
+
     /*
      - call backend health endpoint
      - download, unpack sqlite database from prepopulate-db

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -1,6 +1,56 @@
 package com.ampliapps.amplisync.devclient;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
 public class SyncDevClient {
+    private static final String DEV_AUTH_HEADER = "dev-local-token";
+
+    private final String syncBaseUrl;
+    private final HttpClient httpClient;
+
+    public SyncDevClient(String syncBaseUrl) {
+        this.syncBaseUrl = normalizeBaseUrl(syncBaseUrl);
+        this.httpClient = HttpClient.newHttpClient();
+    }
+
+    public String healthCheck() {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(syncBaseUrl))
+                .header("Authorization", DEV_AUTH_HEADER)
+                .GET()
+                .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IllegalStateException("Health check failed with status: " + response.statusCode());
+            }
+            return response.body();
+        } catch (IOException e) {
+            throw new IllegalStateException("Health check request failed", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Health check request was interrupted", e);
+        }
+    }
+
+    public String syncBaseUrl() {
+        return syncBaseUrl;
+    }
+
+    private static String normalizeBaseUrl(String syncBaseUrl) {
+        if (syncBaseUrl == null || syncBaseUrl.isBlank()) {
+            throw new IllegalArgumentException("syncBaseUrl cannot be empty");
+        }
+
+        return syncBaseUrl.endsWith("/") ? syncBaseUrl : syncBaseUrl + "/";
+    }
+
     /*
      - call backend health endpoint
      - download, unpack sqlite database from prepopulate-db


### PR DESCRIPTION
## Note

 This part was already shown and reviewed in the previous draft PR #101. 


## Summary
- Added initial Java dev client in `tools/dev-client`.
- Added backend health check.
- Added database archive download and unpack
- Added local SQLite opening 
- Added a simple manual runner to verify.

## Current  flow

healthcheck -> prepopulate-db -> unpack SQLite -> open SQLite -> read demo customers

## Goal
first step toward backend regression testing

 ## Tested
- `mvn compile` in `tools/dev-client`
- Manual `DevClientRunner` , with local Docker backend running