### PR TITLE
Build dev client push payload

### DIFF
--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DeletedRecord.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DeletedRecord.java
@@ -1,0 +1,7 @@
+package com.ampliapps.amplisync.devclient;
+
+public record DeletedRecord(
+        String table,
+        String rowid
+) {
+}

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -27,7 +27,7 @@ public class DevClientRunner {
             PayloadBuilder payloadBuilder = new PayloadBuilder(database);
 
             System.out.println("Insert changes:");
-            for (TableChanges change : payloadBuilder.findInsertChanges()) {
+            for (TableChanges change : payloadBuilder.buildChanges()) {
                 System.out.println(change);
             }
 
@@ -35,6 +35,11 @@ public class DevClientRunner {
             System.out.println("Updated demo customer: " + customerId);
             System.out.println("Demo customers after update:");
             database.printDemoCustomers();
+
+            System.out.println("Changes after update:");
+            for (TableChanges change : payloadBuilder.buildChanges()) {
+                System.out.println(change);
+            }
 
             database.deleteDemoCustomer(customerId);
             System.out.println("Deleted demo customer: " + customerId);

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -50,11 +50,16 @@ public class DevClientRunner {
                 System.out.println(change);
             }
 
-
             database.deleteDemoCustomer(customerId);
             System.out.println("Deleted demo customer: " + customerId);
             System.out.println("Demo customers after delete:");
             database.printDemoCustomers();
+
+            System.out.println("Deleted records:");
+            for (DeletedRecord deletedRecord : database.findDeletedRecords()) {
+                System.out.println(deletedRecord);
+            }
+
         }
     }
 }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -60,6 +60,9 @@ public class DevClientRunner {
                 System.out.println(deletedRecord);
             }
 
+            System.out.println("Full push payload:");
+            System.out.println(payloadBuilder.buildPushPayload());
+
         }
     }
 }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -24,6 +24,13 @@ public class DevClientRunner {
             System.out.println("Demo customers after insert:");
             database.printDemoCustomers();
 
+            PayloadBuilder payloadBuilder = new PayloadBuilder(database);
+
+            System.out.println("Insert changes:");
+            for (TableChanges change : payloadBuilder.findInsertChanges()) {
+                System.out.println(change);
+            }
+
             database.updateDemoCustomerCity(customerId, "Krakow");
             System.out.println("Updated demo customer: " + customerId);
             System.out.println("Demo customers after update:");

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -41,6 +41,16 @@ public class DevClientRunner {
                 System.out.println(change);
             }
 
+            String existingCustomerId = database.findFirstExistingCustomer();
+            database.updateDemoCustomerCity(existingCustomerId, "Lodz");
+
+            System.out.println("Updated existing demo customer: " + existingCustomerId);
+            System.out.println("Changes after existing customer update:");
+            for (TableChanges change : payloadBuilder.buildChanges()) {
+                System.out.println(change);
+            }
+
+
             database.deleteDemoCustomer(customerId);
             System.out.println("Deleted demo customer: " + customerId);
             System.out.println("Demo customers after delete:");

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -28,6 +28,11 @@ public class DevClientRunner {
             System.out.println("Updated demo customer: " + customerId);
             System.out.println("Demo customers after update:");
             database.printDemoCustomers();
+
+            database.deleteDemoCustomer(customerId);
+            System.out.println("Deleted demo customer: " + customerId);
+            System.out.println("Demo customers after delete:");
+            database.printDemoCustomers();
         }
     }
 }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -14,9 +14,20 @@ public class DevClientRunner {
 
         try (SqliteDatabase database = SqliteDatabase.open(databasePath)) {
             System.out.println("demo_customers exists: " + database.tableExists("demo_customers"));
-            System.out.println("Demo customers:");
+            String customerId = database.insertDemoCustomer(
+                    "Dev Client Customer",
+                    "client@gmail.com",
+                    "Warsaw"
+            );
+
+            System.out.println("Inserted demo customer: " + customerId);
+            System.out.println("Demo customers after insert:");
             database.printDemoCustomers();
 
+            database.updateDemoCustomerCity(customerId, "Krakow");
+            System.out.println("Updated demo customer: " + customerId);
+            System.out.println("Demo customers after update:");
+            database.printDemoCustomers();
         }
     }
 }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PayloadBuilder.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PayloadBuilder.java
@@ -12,11 +12,12 @@ public class PayloadBuilder {
         this.database = database;
     }
 
-    public List<TableChanges> findInsertChanges() {
+    public List<TableChanges> buildChanges() {
         List<TableChanges> changes = new ArrayList<>();
 
         for (String tableName : database.findSynchronizedTables()) {
             List<Map<String, Object>> inserts = database.findRowsWithNullRowId(tableName);
+            List<Map<String, Object>> updates = database.findRowsWithMergeUpdate(tableName);
 
             if (!inserts.isEmpty()) {
                 changes.add(new TableChanges(tableName, inserts, Collections.emptyList()));

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PayloadBuilder.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PayloadBuilder.java
@@ -7,8 +7,18 @@ import java.util.Map;
 public class PayloadBuilder {
     private final SqliteDatabase database;
 
+    public record PushPayload(
+            List<TableChanges> changes,
+            List<DeletedRecord> deletes
+    ) {
+    }
+
     public PayloadBuilder(SqliteDatabase database) {
         this.database = database;
+    }
+
+    public PushPayload buildPushPayload() {
+        return new PushPayload(buildChanges(), database.findDeletedRecords());
     }
 
     public List<TableChanges> buildChanges() {
@@ -18,7 +28,7 @@ public class PayloadBuilder {
             List<Map<String, Object>> inserts = database.findRowsWithNullRowId(tableName);
             List<Map<String, Object>> updates = database.findRowsWithMergeUpdate(tableName);
 
-            if (!inserts.isEmpty()) {
+            if (!inserts.isEmpty() || !updates.isEmpty()) {
                 changes.add(new TableChanges(tableName, inserts, updates));
             }
         }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PayloadBuilder.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PayloadBuilder.java
@@ -1,7 +1,6 @@
 package com.ampliapps.amplisync.devclient;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -20,7 +19,7 @@ public class PayloadBuilder {
             List<Map<String, Object>> updates = database.findRowsWithMergeUpdate(tableName);
 
             if (!inserts.isEmpty()) {
-                changes.add(new TableChanges(tableName, inserts, Collections.emptyList()));
+                changes.add(new TableChanges(tableName, inserts, updates));
             }
         }
 

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PayloadBuilder.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PayloadBuilder.java
@@ -1,13 +1,28 @@
 package com.ampliapps.amplisync.devclient;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 public class PayloadBuilder {
     private final SqliteDatabase database;
 
-    public PayloadBuilder (SqliteDatabase database){
+    public PayloadBuilder(SqliteDatabase database) {
         this.database = database;
     }
-/// printing for now
-    public void printNewInserts(){
-        database.printNewInserts();
+
+    public List<TableChanges> findInsertChanges() {
+        List<TableChanges> changes = new ArrayList<>();
+
+        for (String tableName : database.findSynchronizedTables()) {
+            List<Map<String, Object>> inserts = database.findRowsWithNullRowId(tableName);
+
+            if (!inserts.isEmpty()) {
+                changes.add(new TableChanges(tableName, inserts, Collections.emptyList()));
+            }
+        }
+
+        return changes;
     }
 }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PayloadBuilder.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PayloadBuilder.java
@@ -1,0 +1,13 @@
+package com.ampliapps.amplisync.devclient;
+
+public class PayloadBuilder {
+    private final SqliteDatabase database;
+
+    public PayloadBuilder (SqliteDatabase database){
+        this.database = database;
+    }
+/// printing for now
+    public void printNewInserts(){
+        database.printNewInserts();
+    }
+}

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -204,6 +204,27 @@ public class SqliteDatabase implements AutoCloseable {
         }
     }
 
+    public String findFirstExistingCustomer() {
+        String sql = """
+              select id
+              from demo_customers
+              where rowid is not null
+              limit 1
+              """;
+
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            if (!resultSet.next()) {
+                throw new IllegalStateException("No existing demo customer found");
+            }
+
+            return resultSet.getString("id");
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to find existing demo customer", e);
+        }
+    }
+
+
     @Override
     public void close() {
         try {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -78,6 +78,22 @@ public class SqliteDatabase implements AutoCloseable {
         }
     }
 
+    public void updateDemoCustomerCity(String customerId, String city) {
+        String sql = """
+              update demo_customers
+              set city = ?
+              where id = ?
+              """;
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, city);
+            statement.setString(2, customerId);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to update demo customer", e);
+        }
+    }
+
     @Override
     public void close() {
         try {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -85,7 +85,7 @@ public class SqliteDatabase implements AutoCloseable {
     }
 
     public List<Map<String, Object>> findRowsWithMergeUpdate(String tableName) {
-        String sql = "select * from " + tableName + "where mergeupdate > 0 and rowid is not null";
+        String sql = "select * from " + tableName + " where mergeupdate > 0 and rowid is not null";
 
         try (Statement statement = connection.createStatement();
              ResultSet resultSet = statement.executeQuery(sql)) {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -94,6 +94,20 @@ public class SqliteDatabase implements AutoCloseable {
         }
     }
 
+    public void deleteDemoCustomer(String customerId) {
+        String sql = """
+              delete from demo_customers
+              where id = ?
+              """;
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, customerId);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to delete demo customer", e);
+        }
+    }
+
     @Override
     public void close() {
         try {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -59,6 +59,26 @@ public class SqliteDatabase implements AutoCloseable {
         }
     }
 
+    public void printNewInserts() {
+        String sql = """
+            select id, name, email, city
+            from demo_customers
+            where rowid is null
+            """;
+
+        try (Statement statement = connection.createStatement();
+            ResultSet resultSet = statement.executeQuery(sql)){
+                while (resultSet.next()){
+                    System.out.println(
+                            resultSet.getString("id") + " | " + resultSet.getString("name") + " | " + resultSet.getString("email") + " | " + resultSet.getString("city")
+                    );
+                }
+        }catch (SQLException e) {
+                throw new IllegalStateException("Failed to print new inserts with rowid = null");
+        }
+
+    }
+
     public String insertDemoCustomer(String name, String email, String city) {
         String id = UUID.randomUUID().toString();
         String sql = """

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -7,6 +7,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.UUID;
 
 public class SqliteDatabase implements AutoCloseable {
     private final Connection connection;
@@ -58,6 +59,24 @@ public class SqliteDatabase implements AutoCloseable {
         }
     }
 
+    public String insertDemoCustomer(String name, String email, String city) {
+        String id = UUID.randomUUID().toString();
+        String sql = """
+              insert into demo_customers (id, name, email, city)
+              values (?, ?, ?, ?)
+              """;
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, id);
+            statement.setString(2, name);
+            statement.setString(3, email);
+            statement.setString(4, city);
+            statement.executeUpdate();
+            return id;
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to insert demo customer", e);
+        }
+    }
 
     @Override
     public void close() {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -225,7 +225,11 @@ public class SqliteDatabase implements AutoCloseable {
     }
 
     public List<DeletedRecord> findDeletedRecords() {
-        String sql = "select tableid, rowid from mergedelete";
+        String sql = """
+                        select tableid, rowid 
+                        from mergedelete
+                        where rowid is not null
+                        """;
 
         List<DeletedRecord> deletes = new ArrayList<>();
 

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -224,6 +224,26 @@ public class SqliteDatabase implements AutoCloseable {
         }
     }
 
+    public List<DeletedRecord> findDeletedRecords() {
+        String sql = "select tableid, rowid from mergedelete";
+
+        List<DeletedRecord> deletes = new ArrayList<>();
+
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            while (resultSet.next()) {
+                deletes.add(new DeletedRecord(
+                        resultSet.getString("tableid"),
+                        resultSet.getString("rowid")
+                ));
+            }
+
+            return deletes;
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to find deleted records", e);
+        }
+    }
+
 
     @Override
     public void close() {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -84,6 +84,17 @@ public class SqliteDatabase implements AutoCloseable {
         }
     }
 
+    public List<Map<String, Object>> findRowsWithMergeUpdate(String tableName) {
+        String sql = "select * from " + tableName + "where mergeupdate > 0 and rowid is not null";
+
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            return toRows(resultSet);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to find updates for table: " + tableName, e);
+        }
+    }
+
     private static List<Map<String, Object>> toRows(ResultSet resultSet) throws SQLException {
         List<Map<String, Object>> rows = new ArrayList<>();
         ResultSetMetaData metaData = resultSet.getMetaData();

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -8,6 +8,12 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.UUID;
+import java.sql.ResultSetMetaData;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 
 public class SqliteDatabase implements AutoCloseable {
     private final Connection connection;
@@ -43,6 +49,65 @@ public class SqliteDatabase implements AutoCloseable {
             throw new IllegalStateException("Failed to check SQLite table: " + tableName, e);
         }
     }
+
+    public List<String> findSynchronizedTables() {
+        String sql = """
+              select tbl_name
+              from sqlite_master
+              where type = 'table'
+                and sql like '%rowid%'
+                and tbl_name != 'mergedelete'
+              """;
+
+        List<String> tableNames = new ArrayList<>();
+
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            while (resultSet.next()) {
+                tableNames.add(resultSet.getString("tbl_name"));
+            }
+
+            return tableNames;
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to find synchronized tables", e);
+        }
+    }
+
+    public List<Map<String, Object>> findRowsWithNullRowId(String tableName) {
+        String sql = "select * from " + tableName + " where rowid is null";
+
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            return toRows(resultSet);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to find inserts for table: " + tableName, e);
+        }
+    }
+
+    private static List<Map<String, Object>> toRows(ResultSet resultSet) throws SQLException {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        ResultSetMetaData metaData = resultSet.getMetaData();
+        int columnCount = metaData.getColumnCount();
+
+        while (resultSet.next()) {
+            Map<String, Object> row = new LinkedHashMap<>();
+
+            for (int columnIndex = 1; columnIndex <= columnCount; columnIndex++) {
+                String columnName = metaData.getColumnName(columnIndex);
+
+                if ("mergeupdate".equals(columnName)) {
+                    continue;
+                }
+
+                row.put(columnName, resultSet.getObject(columnIndex));
+            }
+
+            rows.add(row);
+        }
+
+        return rows;
+    }
+
 
     public void printDemoCustomers() {
         String sql = "select id, name, email, city from demo_customers";

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/TableChanges.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/TableChanges.java
@@ -1,0 +1,11 @@
+package com.ampliapps.amplisync.devclient;
+
+import java.util.List;
+import java.util.Map;
+
+public record TableChanges(
+        String table,
+        List<Map<String, Object>> inserts,
+        List<Map<String, Object>> updates
+) {
+}


### PR DESCRIPTION
## Summary

Adds payload building for local SQLite changes 

This PR adds the logic needed to detect local changes and prepare a push payload.

## Included

- added local demo insert/update/delete operations in the runner
- added `PayloadBuilder`
- detects local inserts from rows with `rowid is null`
- detects local updates from rows with `mergeupdate > 0`
- detects local deletes from `mergedelete`
- builds full push payload with `changes` and `deletes`

## Not included yet

This PR does not send the payload to the backend and does not clear local change markers after push. (in next PR)

## Notes

The runner still uses demo customer operations for now.
The next PR will replace them with generic `insert`, `update` and `delete` methods 

## Tested: 
- `mvn compile` in `tools/dev-client`
- manual `DevClientRunner` with local Docker backend running
-  - verified generated payload output for local insert/update/delete
