### PR TITLE
Add dev client pull flow

### DIFF
--- a/tools/dev-client/README.md
+++ b/tools/dev-client/README.md
@@ -4,53 +4,71 @@ Java client for checking the ampli-sync backend synchronization flow without usi
 
 Idea: follow the same sync flow as the React Native example, but in a simpler form for manual checks and regression tests.
 
-## Implemented so far
+## What it does
 
 - backend health check,
 - download SQLite database archive from `prepopulate-db`,
 - unpack downloaded database archive,
 - open local SQLite database,
-- check that demo tables exist, print content in runner
-
-## Planned scope
-
-
-1. Add local SQLite operations: insert, update, delete
-
-2. Build payload with changes from local SQLite, following the logic:
-   - rows with `rowid is null` as inserts,
-   - rows with `mergeupdate > 0 and rowid is not null` as updates,
-   - rows from `mergedelete` as deletes.
-
-3. Send local changes to backend:
-   - call `receive-changes/`,
-   - verify that pushed data appears in PostgreSQL.
-
-4. Pull changes from backend:
-   - call sync endpoint for selected tables,
-   - apply returned changes to local SQLite.
-
-5. Use this client in full integration and regression tests:
- 
+- insert, update and delete local rows,
+- build push payload from local SQLite changes,
+- send local changes to the backend through `receive-changes`,
+- clear local change markers after successful push,
+- pull changes from the backend through `sync-compressed`,
+- apply pulled inserts, updates and deletes to local SQLite,
+- call `commit-sync` after applying pulled changes.
 
 ## Structure
 
 - `SyncDevClient` handles  communication with the ampli-sync backend.
 - `SqliteDatabase` handles local SQLite access.
-- Push payload builder - work in progress
+- `PayloadBuilder` builds the push payload from local SQLite changes.
+- `SyncDevice` represents one local sync device with its device id and SQLite database.
+- `DevClientRunner` is a simple manual runner for checking the flow locally.
+
+Helper records:
+
+- `TableChanges` represents inserts and updates for one synchronized table.
+- `DeletedRecord` - one deleted record sent in the push payload.
+- `PayloadBuildResult` groups the push payload with cleanup statements.
+- `ProcessedSqlStatement` SQL cleanup statement with arguments.
+- `PullChanges` represents one table change package returned by `sync-compressed`.
+- `PullRecords` contains pulled inserts, updates and deletes.
+
 
 ## Test - Manual check
 
-With the local Docker backend running, I run `DevClientRunner`.
+Start the local backend from deploy-dev/docker.
 
-Output:
+Then run:
 
-```text
-API[bb924e2] OK! Database connected!
-demo_customers exists: true
-Demo customers:
-0b8e9b8e-0fb5-4f2d-8d4c-3c57e7dc8e47 | North Coast Shop | hello@northcoast.example | Gdansk
-5e7b16b0-0c2f-4e9d-9f74-2d7a8f4c0b21 | Acme Retail | orders@acme.example | Warsaw
-8fb5f9c7-9929-4f87-8fcb-19f2092f0a5d | Green Market | contact@greenmarket.example | Poznan
-ad6510d7-c44f-4cfa-94c3-3f56a32a4c89 | Metro Office | office@metro.example | Krakow
 ```
+cd tools/dev-client
+mvn compile
+```
+
+Run `DevClientRunner`.
+
+The runner creates two local devices:
+
+`deviceA`
+`deviceB`
+
+Example flow:
+```
+deviceA prepopulate-db
+deviceB prepopulate-db
+deviceA insert/update/delete local SQLite records
+deviceA push changes to backend
+deviceB pull changes from backend
+deviceB applies pulled changes locally
+deviceB commit-sync
+```
+Expected result:
+```
+Device B inserted customer name: Inserted From Device A
+Device B updated customer city: Wroclaw
+Device B deleted customer is gone: 'customer-id'
+```
+
+## WiP: Automated Regression Tests with Testcontainers

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -1,51 +1,42 @@
 package com.ampliapps.amplisync.devclient;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
-import java.util.List;
 
 public class DevClientRunner {
     public static void main(String[] args) throws Exception {
-
         SyncDevClient client = new SyncDevClient("http://localhost:8080/ampli-sync/");
-        ObjectMapper objectMapper = new ObjectMapper();
 
-        String deviceA = "dev-client-device-a";
-        String deviceB = "dev-client-device-b";
+        String deviceAId = argumentOrDefault(args, 0, "dev-client-device-a");
+        String deviceBId = argumentOrDefault(args, 1, "dev-client-device-b");
 
-        Path deviceADirectory = Path.of("/tmp/ampli-sync-dev-client/device-a");
-        Path deviceBDirectory = Path.of("/tmp/ampli-sync-dev-client/device-b");
-
-        Path deviceAArchive = client.downloadPrepopulatedDatabaseArchive(deviceA, deviceADirectory);
-        Path deviceADatabasePath = client.unpackDatabaseArchive(deviceAArchive, deviceADirectory);
-
-        Path deviceBArchive = client.downloadPrepopulatedDatabaseArchive(deviceB, deviceBDirectory);
-        Path deviceBDatabasePath = client.unpackDatabaseArchive(deviceBArchive, deviceBDirectory);
-
-        try (SqliteDatabase deviceADatabase = SqliteDatabase.open(deviceADatabasePath);
-             SqliteDatabase deviceBDatabase = SqliteDatabase.open(deviceBDatabasePath)) {
-
-            PayloadBuilder deviceAPayloadBuilder = new PayloadBuilder(deviceADatabase);
+        try (SyncDevice deviceA = new SyncDevice(
+                client,
+                deviceAId,
+                Path.of("/tmp/ampli-sync-dev-client/device-a")
+        );
+             SyncDevice deviceB = new SyncDevice(
+                     client,
+                     deviceBId,
+                     Path.of("/tmp/ampli-sync-dev-client/device-b")
+             )) {
+            deviceA.prepopulate();
+            deviceB.prepopulate();
 
             String insertedCustomerId = UUID.randomUUID().toString();
+            String updatedCustomerId = "0b8e9b8e-0fb5-4f2d-8d4c-3c57e7dc8e47";
+            String deletedCustomerId = "8fb5f9c7-9929-4f87-8fcb-19f2092f0a5d";
 
-            Map<String, Object> insertedCustomer = Map.of(
+            deviceA.insertRow("demo_customers", Map.of(
                     "id", insertedCustomerId,
                     "name", "Inserted From Device A",
                     "email", "inserted-device-a@example.com",
                     "city", "Warsaw"
-            );
-
-            String updatedCustomerId = "0b8e9b8e-0fb5-4f2d-8d4c-3c57e7dc8e47";
-            String deletedCustomerId = "8fb5f9c7-9929-4f87-8fcb-19f2092f0a5d";
-
-            deviceADatabase.insertRow("demo_customers", insertedCustomer);
+            ));
             System.out.println("Device A inserted customer: " + insertedCustomerId);
 
-            deviceADatabase.updateRow(
+            deviceA.updateRow(
                     "demo_customers",
                     Map.of("city", "Wroclaw"),
                     "id",
@@ -53,35 +44,22 @@ public class DevClientRunner {
             );
             System.out.println("Device A updated customer: " + updatedCustomerId);
 
-            deviceADatabase.deleteRow("demo_customers", "id", deletedCustomerId);
+            deviceA.deleteRow("demo_customers", "id", deletedCustomerId);
             System.out.println("Device A deleted customer: " + deletedCustomerId);
 
-            PayloadBuildResult pushResult = deviceAPayloadBuilder.buildPushPayloadResult();
-
-            System.out.println("Device A push payload:");
-            System.out.println(objectMapper.writeValueAsString(pushResult.payload()));
-
-            client.sendChanges(deviceA, pushResult.payload());
+            deviceA.push();
             System.out.println("Device A pushed changes.");
 
-            deviceADatabase.clearProcessedChanges(pushResult);
-            System.out.println("Device A local markers cleared.");
+            deviceB.pullTable("demo_customers");
+            System.out.println("Device B pulled changes.");
 
-            List<PullChanges> deviceBPullChanges = client.pullChangesForTable("demo_customers", deviceB);
-
-            System.out.println("Device B pull response:");
-            System.out.println(objectMapper.writeValueAsString(deviceBPullChanges));
-
-            deviceBDatabase.applyPullChanges(deviceBPullChanges);
-            System.out.println("Device B applied pulled changes.");
-
-            String insertedCustomerNameOnB = deviceBDatabase.findFirstValue(
+            String insertedCustomerNameOnB = deviceB.findFirstValue(
                     "demo_customers",
                     "name",
                     "id = '" + insertedCustomerId + "'"
             );
 
-            String updatedCustomerCityOnB = deviceBDatabase.findFirstValue(
+            String updatedCustomerCityOnB = deviceB.findFirstValue(
                     "demo_customers",
                     "city",
                     "id = '" + updatedCustomerId + "'"
@@ -91,9 +69,9 @@ public class DevClientRunner {
             System.out.println("Device B updated customer city: " + updatedCustomerCityOnB);
 
             try {
-                deviceBDatabase.findFirstValue(
+                deviceB.findFirstValue(
                         "demo_customers",
-                        "id",
+                        "city",
                         "id = '" + deletedCustomerId + "'"
                 );
 
@@ -102,8 +80,10 @@ public class DevClientRunner {
                 System.out.println("Device B deleted customer is gone: " + deletedCustomerId);
             }
         }
-
-
     }
-}
 
+    private static String argumentOrDefault(String[] args, int index, String defaultValue) {
+        return args.length > index ? args[index] : defaultValue;
+    }
+
+}

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -56,13 +56,15 @@ public class DevClientRunner {
             String insertedCustomerNameOnB = deviceB.findFirstValue(
                     "demo_customers",
                     "name",
-                    "id = '" + insertedCustomerId + "'"
+                    "id",
+                    insertedCustomerId
             );
 
             String updatedCustomerCityOnB = deviceB.findFirstValue(
                     "demo_customers",
                     "city",
-                    "id = '" + updatedCustomerId + "'"
+                    "id",
+                    updatedCustomerId
             );
 
             System.out.println("Device B inserted customer name: " + insertedCustomerNameOnB);
@@ -72,7 +74,8 @@ public class DevClientRunner {
                 deviceB.findFirstValue(
                         "demo_customers",
                         "city",
-                        "id = '" + deletedCustomerId + "'"
+                        "id",
+                        deletedCustomerId
                 );
 
                 System.out.println("Device B deleted customer still exists: " + deletedCustomerId);

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -9,73 +9,101 @@ import java.util.List;
 
 public class DevClientRunner {
     public static void main(String[] args) throws Exception {
-        String deviceId = "dev-client-device-1";
 
         SyncDevClient client = new SyncDevClient("http://localhost:8080/ampli-sync/");
         ObjectMapper objectMapper = new ObjectMapper();
 
-        System.out.println(client.healthCheck());
+        String deviceA = "dev-client-device-a";
+        String deviceB = "dev-client-device-b";
 
-        Path outputDirectory = Path.of("/tmp/ampli-sync-dev-client");
-        Path archivePath = client.downloadPrepopulatedDatabaseArchive(deviceId, outputDirectory);
-        Path databasePath = client.unpackDatabaseArchive(archivePath, outputDirectory);
+        Path deviceADirectory = Path.of("/tmp/ampli-sync-dev-client/device-a");
+        Path deviceBDirectory = Path.of("/tmp/ampli-sync-dev-client/device-b");
 
-        try (SqliteDatabase database = SqliteDatabase.open(databasePath)) {
-            PayloadBuilder payloadBuilder = new PayloadBuilder(database);
+        Path deviceAArchive = client.downloadPrepopulatedDatabaseArchive(deviceA, deviceADirectory);
+        Path deviceADatabasePath = client.unpackDatabaseArchive(deviceAArchive, deviceADirectory);
 
-            String customerId = UUID.randomUUID().toString();
+        Path deviceBArchive = client.downloadPrepopulatedDatabaseArchive(deviceB, deviceBDirectory);
+        Path deviceBDatabasePath = client.unpackDatabaseArchive(deviceBArchive, deviceBDirectory);
 
-            Map<String, Object> customer = Map.of(
-                    "id", customerId,
-                    "name", "Dev Client Customer",
-                    "email", "client@gmail.com",
+        try (SqliteDatabase deviceADatabase = SqliteDatabase.open(deviceADatabasePath);
+             SqliteDatabase deviceBDatabase = SqliteDatabase.open(deviceBDatabasePath)) {
+
+            PayloadBuilder deviceAPayloadBuilder = new PayloadBuilder(deviceADatabase);
+
+            String insertedCustomerId = UUID.randomUUID().toString();
+
+            Map<String, Object> insertedCustomer = Map.of(
+                    "id", insertedCustomerId,
+                    "name", "Inserted From Device A",
+                    "email", "inserted-device-a@example.com",
                     "city", "Warsaw"
             );
 
+            String updatedCustomerId = "0b8e9b8e-0fb5-4f2d-8d4c-3c57e7dc8e47";
+            String deletedCustomerId = "8fb5f9c7-9929-4f87-8fcb-19f2092f0a5d";
 
-            database.insertRow("demo_customers", customer);
-            System.out.println("Inserted demo customer: " + customerId);
+            deviceADatabase.insertRow("demo_customers", insertedCustomer);
+            System.out.println("Device A inserted customer: " + insertedCustomerId);
 
-            String existingCustomerId = database.findFirstValue(
+            deviceADatabase.updateRow(
                     "demo_customers",
+                    Map.of("city", "Wroclaw"),
                     "id",
-                    "rowid is not null"
+                    updatedCustomerId
+            );
+            System.out.println("Device A updated customer: " + updatedCustomerId);
+
+            deviceADatabase.deleteRow("demo_customers", "id", deletedCustomerId);
+            System.out.println("Device A deleted customer: " + deletedCustomerId);
+
+            PayloadBuildResult pushResult = deviceAPayloadBuilder.buildPushPayloadResult();
+
+            System.out.println("Device A push payload:");
+            System.out.println(objectMapper.writeValueAsString(pushResult.payload()));
+
+            client.sendChanges(deviceA, pushResult.payload());
+            System.out.println("Device A pushed changes.");
+
+            deviceADatabase.clearProcessedChanges(pushResult);
+            System.out.println("Device A local markers cleared.");
+
+            List<PullChanges> deviceBPullChanges = client.pullChangesForTable("demo_customers", deviceB);
+
+            System.out.println("Device B pull response:");
+            System.out.println(objectMapper.writeValueAsString(deviceBPullChanges));
+
+            deviceBDatabase.applyPullChanges(deviceBPullChanges);
+            System.out.println("Device B applied pulled changes.");
+
+            String insertedCustomerNameOnB = deviceBDatabase.findFirstValue(
+                    "demo_customers",
+                    "name",
+                    "id = '" + insertedCustomerId + "'"
             );
 
-            database.updateRow(
+            String updatedCustomerCityOnB = deviceBDatabase.findFirstValue(
                     "demo_customers",
-                    Map.of("city", "Lodz"),
-                    "id",
-                    existingCustomerId
+                    "city",
+                    "id = '" + updatedCustomerId + "'"
             );
 
-            System.out.println("Updated existing demo customer: " + existingCustomerId);
+            System.out.println("Device B inserted customer name: " + insertedCustomerNameOnB);
+            System.out.println("Device B updated customer city: " + updatedCustomerCityOnB);
 
-            database.deleteRow("demo_customers", "id", customerId);
-            System.out.println("Deleted freshly inserted demo customer: " + customerId);
+            try {
+                deviceBDatabase.findFirstValue(
+                        "demo_customers",
+                        "id",
+                        "id = '" + deletedCustomerId + "'"
+                );
 
-            PayloadBuildResult result = payloadBuilder.buildPushPayloadResult();
-
-            System.out.println("Push payload JSON:");
-            System.out.println(objectMapper.writeValueAsString(result.payload()));
-
-            client.sendChanges(deviceId, result.payload());
-            System.out.println("Push payload sent to backend.");
-
-            database.clearProcessedChanges(result);
-            System.out.println("Local processed changes cleared.");
-
-            System.out.println("Payload after cleanup:");
-            System.out.println(objectMapper.writeValueAsString(payloadBuilder.buildPushPayload()));
-
-            List<PullChanges> pullResponse = client.pullChangesForTable("demo_customers", deviceId);
-
-
-            System.out.println("Pull changes response:");
-            System.out.println(objectMapper.writeValueAsString(pullResponse));
-
-
+                System.out.println("Device B deleted customer still exists: " + deletedCustomerId);
+            } catch (IllegalStateException e) {
+                System.out.println("Device B deleted customer is gone: " + deletedCustomerId);
+            }
         }
+
+
     }
 }
 

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
+import java.util.List;
 
 public class DevClientRunner {
     public static void main(String[] args) throws Exception {
@@ -67,10 +68,12 @@ public class DevClientRunner {
             System.out.println("Payload after cleanup:");
             System.out.println(objectMapper.writeValueAsString(payloadBuilder.buildPushPayload()));
 
-            String pullResponse = client.pullChangesForTable("demo_customers", deviceId);
+            List<PullChanges> pullResponse = client.pullChangesForTable("demo_customers", deviceId);
+
 
             System.out.println("Pull changes response:");
-            System.out.println(pullResponse);
+            System.out.println(objectMapper.writeValueAsString(pullResponse));
+
 
         }
     }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -66,6 +66,12 @@ public class DevClientRunner {
 
             System.out.println("Payload after cleanup:");
             System.out.println(objectMapper.writeValueAsString(payloadBuilder.buildPushPayload()));
+
+            String pullResponse = client.pullChangesForTable("demo_customers", deviceId);
+
+            System.out.println("Pull changes response:");
+            System.out.println(pullResponse);
+
         }
     }
 }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PullChanges.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PullChanges.java
@@ -1,10 +1,13 @@
 package com.ampliapps.amplisync.devclient;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 
 import java.util.List;
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record PullChanges(
         @JsonProperty("TableName")
         String tableName,

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PullChanges.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/PullChanges.java
@@ -1,0 +1,51 @@
+package com.ampliapps.amplisync.devclient;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Map;
+
+public record PullChanges(
+        @JsonProperty("TableName")
+        String tableName,
+
+        @JsonProperty("Records")
+        PullRecords records,
+
+        @JsonProperty("QueryInsert")
+        String queryInsert,
+
+        @JsonProperty("QueryUpdate")
+        String queryUpdate,
+
+        @JsonProperty("QueryDelete")
+        String queryDelete,
+
+        @JsonProperty("TriggerInsert")
+        String triggerInsert,
+
+        @JsonProperty("TriggerUpdate")
+        String triggerUpdate,
+
+        @JsonProperty("TriggerDelete")
+        String triggerDelete,
+
+        @JsonProperty("TriggerInsertDrop")
+        String triggerInsertDrop,
+
+        @JsonProperty("TriggerUpdateDrop")
+        String triggerUpdateDrop,
+
+        @JsonProperty("TriggerDeleteDrop")
+        String triggerDeleteDrop,
+
+        @JsonProperty("SyncId")
+        int syncId
+) {
+    public record PullRecords(
+            List<Map<String, Object>> inserts,
+            List<Map<String, Object>> updates,
+            List<Map<String, Object>> deletes
+    ) {
+    }
+}

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -1,5 +1,6 @@
 package com.ampliapps.amplisync.devclient;
 
+import javax.xml.transform.Result;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -395,16 +396,19 @@ public class SqliteDatabase implements AutoCloseable {
     }
 
 
-    public String findFirstValue(String tableName, String columnName, String whereClause) {
-        String sql = "select " + columnName + " from " + tableName + " where " + whereClause + " limit 1";
+    public String findFirstValue(String tableName, String columnName, String whereColumn, Object whereValue) {
+        String sql = "select " + columnName + " from " + tableName + " where " + whereColumn + " = ? limit 1";
 
-        try (Statement statement = connection.createStatement();
-             ResultSet resultSet = statement.executeQuery(sql)) {
-            if (!resultSet.next()) {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+             statement.setObject(1, whereValue);
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getString(columnName);
+                }
+
                 throw new IllegalStateException("No row found in table: " + tableName);
             }
-
-            return resultSet.getString(columnName);
         } catch (SQLException e) {
             throw new IllegalStateException("Failed to find first value in table: " + tableName, e);
         }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -265,8 +265,52 @@ public class SqliteDatabase implements AutoCloseable {
     }
 
     private void applyPullInserts(PullChanges change) {
-        throw new UnsupportedOperationException("todo");
+        List<Map<String, Object>> inserts = change.records().inserts();
+
+        if (inserts == null || inserts.isEmpty()) {
+            return;
+        }
+
+        List<String> columns = extractColumnsFromInserts(change.queryInsert());
+
+        for (Map<String, Object> record : inserts) {
+            List<Object> args = new ArrayList<>();
+
+            for (String column : columns) {
+                args.add(record.get(column));
+            }
+
+            executeSql(change.queryInsert(), args);
+        }
     }
+
+    private static List<String> extractColumnsFromInserts(String queryInsert) {
+        int start = queryInsert.indexOf('(');
+        int end = queryInsert.indexOf(')');
+
+        if (start < 0 || end < 0 || end <= start) {
+            throw new IllegalArgumentException("Cannot extract columns from insert query: " + queryInsert);
+        }
+
+        String columnsPart = queryInsert.substring(start + 1, end);
+
+        List<String> columns = new ArrayList<>();
+
+        for (String column : columnsPart.split(",")) {
+            columns.add(cleanColumnName(column));
+        }
+
+        return columns;
+    }
+
+    private static String cleanColumnName(String columnName) {
+        return columnName
+                .replace("[", "")
+                .replace("]", "")
+                .replace("\"", "")
+                .trim();
+    }
+
 
     private void applyPullUpdates(PullChanges change) {
         throw new UnsupportedOperationException("todo");

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -251,6 +251,9 @@ public class SqliteDatabase implements AutoCloseable {
     }
 
     private void applyPullChange(PullChanges change) {
+        if (change.syncId() <= 0 || change.records() == null) {
+            return;
+        }
         executeSql(change.triggerInsertDrop());
         executeSql(change.triggerUpdateDrop());
         executeSql(change.triggerDeleteDrop());

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -313,7 +313,49 @@ public class SqliteDatabase implements AutoCloseable {
 
 
     private void applyPullUpdates(PullChanges change) {
-        throw new UnsupportedOperationException("todo");
+        List<Map<String, Object>> updates = change.records().updates();
+
+        if (updates == null || updates.isEmpty()) {
+            return;
+        }
+
+        List<String> columns = extractColumnsFromUpdates(change.queryUpdate());
+
+        for (Map<String, Object> record : updates) {
+            List<Object> args = new ArrayList<>();
+
+            for (String column : columns) {
+                args.add(record.get(column));
+            }
+
+            executeSql(change.queryUpdate(), args);
+        }
+    }
+
+    private static List<String> extractColumnsFromUpdates(String queryUpdate) {
+        String lowerQuery = queryUpdate.toLowerCase();
+
+        int setStart = lowerQuery.indexOf(" set ");
+        int whereStart = lowerQuery.indexOf(" where ");
+
+        if (setStart < 0 || whereStart < 0 || whereStart <= setStart) {
+            throw new IllegalArgumentException("Cannot extract columns from update query: " + queryUpdate);
+        }
+
+        String setPart = queryUpdate.substring(setStart + " set ".length(), whereStart);
+        String wherePart = queryUpdate.substring(whereStart + " where ".length()).replace(";", "");
+
+        List<String> columns = new ArrayList<>();
+
+        for (String assignment : setPart.split(",")) {
+            columns.add(cleanColumnName(assignment.split("=")[0]));
+        }
+
+        for (String condition : wherePart.split("(?i)\\s+and\\s+")) {
+            columns.add(cleanColumnName(condition.split("=")[0]));
+        }
+
+        return columns;
     }
 
     private void applyPullDeletes(PullChanges change) {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -227,6 +227,55 @@ public class SqliteDatabase implements AutoCloseable {
         }
     }
 
+    public void executeSql(String sql) {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to execute SQL: " + sql, e);
+        }
+    }
+
+    public void executeSql(String sql, List<Object> args) {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            setStatementArgs(statement, args);
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to execute SQL: " + sql, e);
+        }
+    }
+
+    public void applyPullChanges(List<PullChanges> changes) {
+        for (PullChanges change : changes) {
+            applyPullChange(change);
+        }
+    }
+
+    private void applyPullChange(PullChanges change) {
+        executeSql(change.triggerInsertDrop());
+        executeSql(change.triggerUpdateDrop());
+        executeSql(change.triggerDeleteDrop());
+
+        applyPullInserts(change);
+        applyPullUpdates(change);
+        applyPullDeletes(change);
+
+        executeSql(change.triggerInsert());
+        executeSql(change.triggerUpdate());
+        executeSql(change.triggerDelete());
+    }
+
+    private void applyPullInserts(PullChanges change) {
+        throw new UnsupportedOperationException("todo");
+    }
+
+    private void applyPullUpdates(PullChanges change) {
+        throw new UnsupportedOperationException("todo");
+    }
+
+    private void applyPullDeletes(PullChanges change) {
+        throw new UnsupportedOperationException("todo");
+    }
+
     private static String buildPlaceholders(int count) {
         List<String> placeholders = new ArrayList<>();
 

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -359,7 +359,20 @@ public class SqliteDatabase implements AutoCloseable {
     }
 
     private void applyPullDeletes(PullChanges change) {
-        throw new UnsupportedOperationException("todo");
+        List<Map<String,Object>> deletes = change.records().deletes();
+
+        if (deletes == null || deletes.isEmpty()) {
+            return;
+        }
+
+        String sql = change.queryDelete().contains("?")
+                ? change.queryDelete()
+                : change.queryDelete().trim() + "?";
+
+        for (Map<String, Object> record : deletes) {
+            executeSql(sql, List.of(record.get("rowid")));
+        }
+
     }
 
     private static String buildPlaceholders(int count) {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -167,6 +167,32 @@ public class SyncDevClient {
         }
     }
 
+    public void commitSync(int syncId) {
+        if (syncId <= 0) {
+            return;
+        }
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(syncBaseUrl + "commit-sync/" + syncId))
+                .header("Authorization", DEV_AUTH_HEADER)
+                .GET()
+                .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IllegalStateException("Commit sync failed with status: " + response.statusCode());
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Commit sync request failed", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Commit sync request was interrupted", e);
+        }
+    }
+
+
 
     private static String unzipGzip(byte[] compressedBytes) throws IOException {
         try (GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(compressedBytes))) {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -16,6 +16,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
+import java.util.List;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 
 
@@ -131,7 +133,7 @@ public class SyncDevClient {
         }
     }
 
-    public String pullChangesForTable(String tableName, String deviceId) {
+    public List<PullChanges> pullChangesForTable(String tableName, String deviceId) {
         if (tableName == null || tableName.isBlank()) {
             throw new IllegalArgumentException("tableName can't be empty");
         }
@@ -153,7 +155,10 @@ public class SyncDevClient {
                 throw new IllegalStateException("Pull changes failed with status: " + response.statusCode());
             }
 
-            return unzipGzip(response.body());
+            String json = unzipGzip(response.body());
+
+            return objectMapper.readValue(json, new TypeReference<List<PullChanges>>() {
+            });
         } catch (IOException e) {
             throw new IllegalStateException("Pull changes request failed", e);
         } catch (InterruptedException e) {
@@ -161,6 +166,7 @@ public class SyncDevClient {
             throw new IllegalStateException("Pull changes request was interrupted", e);
         }
     }
+
 
     private static String unzipGzip(byte[] compressedBytes) throws IOException {
         try (GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(compressedBytes))) {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -13,6 +13,10 @@ import java.util.zip.ZipInputStream;
 import com.ampliapps.amplisync.devclient.PayloadBuilder.PushPayload;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPInputStream;
+
 
 
 public class SyncDevClient {
@@ -126,6 +130,44 @@ public class SyncDevClient {
             throw new IllegalStateException("Send changes request was interrupted", e);
         }
     }
+
+    public String pullChangesForTable(String tableName, String deviceId) {
+        if (tableName == null || tableName.isBlank()) {
+            throw new IllegalArgumentException("tableName can't be empty");
+        }
+
+        if (deviceId == null || deviceId.isBlank()) {
+            throw new IllegalArgumentException("deviceId can't be empty");
+        }
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(syncBaseUrl + "sync-compressed/" + tableName + "/" + deviceId))
+                .header("Authorization", DEV_AUTH_HEADER)
+                .GET()
+                .build();
+
+        try {
+            HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IllegalStateException("Pull changes failed with status: " + response.statusCode());
+            }
+
+            return unzipGzip(response.body());
+        } catch (IOException e) {
+            throw new IllegalStateException("Pull changes request failed", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Pull changes request was interrupted", e);
+        }
+    }
+
+    private static String unzipGzip(byte[] compressedBytes) throws IOException {
+        try (GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(compressedBytes))) {
+            return new String(gzipInputStream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
 
 
     public Path unpackDatabaseArchive(Path archivePath, Path outputDirectory) {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
@@ -1,0 +1,92 @@
+package com.ampliapps.amplisync.devclient;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents one local sync device.
+ * Each device has its own id, working directory and local SQLite database.
+ * This class wraps lower level http and db operations into steps:
+ * prepopulate, local changes(insert, update, delete), push and pull.
+ */
+
+public class SyncDevice implements AutoCloseable {
+    private final SyncDevClient client;
+    private final String deviceId;
+    private final Path workDirectory;
+    private SqliteDatabase database;
+
+    public SyncDevice(SyncDevClient client, String deviceId, Path workDirectory) {
+        this.client = client;
+        this.deviceId = deviceId;
+        this.workDirectory = workDirectory;
+    }
+
+    public void prepopulate() {
+        Path archivePath = client.downloadPrepopulatedDatabaseArchive(deviceId, workDirectory);
+        Path databasePath = client.unpackDatabaseArchive(archivePath, workDirectory);
+        database = SqliteDatabase.open(databasePath);
+    }
+
+    public void insertRow(String tableName, Map<String, Object> values) {
+        requireDatabase();
+        database.insertRow(tableName, values);
+    }
+
+    public void updateRow(String tableName, Map<String, Object> values, String whereColumn, Object whereValue) {
+        requireDatabase();
+        database.updateRow(tableName, values, whereColumn, whereValue);
+    }
+
+    public void deleteRow(String tableName, String whereColumn, Object whereValue) {
+        requireDatabase();
+        database.deleteRow(tableName, whereColumn, whereValue);
+    }
+
+    public void push() {
+        requireDatabase();
+
+        PayloadBuilder payloadBuilder = new PayloadBuilder(database);
+        PayloadBuildResult result = payloadBuilder.buildPushPayloadResult();
+
+        client.sendChanges(deviceId, result.payload());
+        database.clearProcessedChanges(result);
+    }
+
+    /**
+     * Pulls changes for one table, applies them locally, and confirms with commitSync on backend.
+     */
+    public void pullTable(String tableName) {
+        requireDatabase();
+
+        List<PullChanges> changes = client.pullChangesForTable(tableName, deviceId);
+        database.applyPullChanges(changes);
+
+        for (PullChanges change : changes) {
+            client.commitSync(change.syncId());
+        }
+    }
+
+    public String findFirstValue(String tableName, String columnName, String whereClause) {
+        requireDatabase();
+        return database.findFirstValue(tableName, columnName, whereClause);
+    }
+
+    public String deviceId() {
+        return deviceId;
+    }
+
+    private void requireDatabase() {
+        if (database == null) {
+            throw new IllegalStateException("Device database is not initialized. Call prepopulate() first.");
+        }
+    }
+
+    @Override
+    public void close() {
+        if (database != null) {
+            database.close();
+        }
+    }
+}

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
@@ -68,9 +68,9 @@ public class SyncDevice implements AutoCloseable {
         }
     }
 
-    public String findFirstValue(String tableName, String columnName, String whereClause) {
+    public String findFirstValue(String tableName, String columnName, String whereColumn, Object whereValue) {
         requireDatabase();
-        return database.findFirstValue(tableName, columnName, whereClause);
+        return database.findFirstValue(tableName, columnName, whereColumn, whereValue);
     }
 
     public String deviceId() {


### PR DESCRIPTION
## Summary

Adds pull flow to  dev client.

 It allows the client to download changes from the backend, decompresses it and parses the json, and apply changes to a local SQLite.

## Included

- added `pullChangesForTable()` in `SyncDevClient`
- added `PullChanges` model for backend pull response
- added GZIP unpack/decompress
- added applying pulled inserts, updates and deletes  to local SQLite
- handles empty pull responses, for example `SyncId = -1`
- updated `DevClientRunner` to do  two-device flow (devices A push, device B pull)

## Test - Current flow in client runner:
Scenario:

```text
deviceA prepopulate-db
deviceB prepopulate-db
deviceA insert/update/delete local SQLite records
deviceA build push payload
deviceA receive-changes
deviceA clear local change markers
deviceB sync-compressed
deviceB apply pulled insert/update/delete records to local SQLite
```
## Notes
`DevClientRunner` will be rebuilt in new PR.

The pull response from the backend has templates such as QueryInsert/update/delete.
The dev client 'mimics' RN client:  it uses templates and fills them with values from returned `records.`

commit-sync is not included yet (in next PR)

## Tested

- mvn compile 
- manual DevClientRunner with local Docker backend
- verified deviceA push -> backend -> deviceB flow for insert update and delete
      

