### PR TITLE
dev client device wrapper + commitSync

### DIFF
--- a/tools/dev-client/README.md
+++ b/tools/dev-client/README.md
@@ -4,53 +4,71 @@ Java client for checking the ampli-sync backend synchronization flow without usi
 
 Idea: follow the same sync flow as the React Native example, but in a simpler form for manual checks and regression tests.
 
-## Implemented so far
+## What it does
 
 - backend health check,
 - download SQLite database archive from `prepopulate-db`,
 - unpack downloaded database archive,
 - open local SQLite database,
-- check that demo tables exist, print content in runner
-
-## Planned scope
-
-
-1. Add local SQLite operations: insert, update, delete
-
-2. Build payload with changes from local SQLite, following the logic:
-   - rows with `rowid is null` as inserts,
-   - rows with `mergeupdate > 0 and rowid is not null` as updates,
-   - rows from `mergedelete` as deletes.
-
-3. Send local changes to backend:
-   - call `receive-changes/`,
-   - verify that pushed data appears in PostgreSQL.
-
-4. Pull changes from backend:
-   - call sync endpoint for selected tables,
-   - apply returned changes to local SQLite.
-
-5. Use this client in full integration and regression tests:
- 
+- insert, update and delete local rows,
+- build push payload from local SQLite changes,
+- send local changes to the backend through `receive-changes`,
+- clear local change markers after successful push,
+- pull changes from the backend through `sync-compressed`,
+- apply pulled inserts, updates and deletes to local SQLite,
+- call `commit-sync` after applying pulled changes.
 
 ## Structure
 
 - `SyncDevClient` handles  communication with the ampli-sync backend.
 - `SqliteDatabase` handles local SQLite access.
-- Push payload builder - work in progress
+- `PayloadBuilder` builds the push payload from local SQLite changes.
+- `SyncDevice` represents one local sync device with its device id and SQLite database.
+- `DevClientRunner` is a simple manual runner for checking the flow locally.
+
+Helper records:
+
+- `TableChanges` represents inserts and updates for one synchronized table.
+- `DeletedRecord` - one deleted record sent in the push payload.
+- `PayloadBuildResult` groups the push payload with cleanup statements.
+- `ProcessedSqlStatement` SQL cleanup statement with arguments.
+- `PullChanges` represents one table change package returned by `sync-compressed`.
+- `PullRecords` contains pulled inserts, updates and deletes.
+
 
 ## Test - Manual check
 
-With the local Docker backend running, I run `DevClientRunner`.
+Start the local backend from deploy-dev/docker.
 
-Output:
+Then run:
 
-```text
-API[bb924e2] OK! Database connected!
-demo_customers exists: true
-Demo customers:
-0b8e9b8e-0fb5-4f2d-8d4c-3c57e7dc8e47 | North Coast Shop | hello@northcoast.example | Gdansk
-5e7b16b0-0c2f-4e9d-9f74-2d7a8f4c0b21 | Acme Retail | orders@acme.example | Warsaw
-8fb5f9c7-9929-4f87-8fcb-19f2092f0a5d | Green Market | contact@greenmarket.example | Poznan
-ad6510d7-c44f-4cfa-94c3-3f56a32a4c89 | Metro Office | office@metro.example | Krakow
 ```
+cd tools/dev-client
+mvn compile
+```
+
+Run `DevClientRunner`.
+
+The runner creates two local devices:
+
+`deviceA`
+`deviceB`
+
+Example flow:
+```
+deviceA prepopulate-db
+deviceB prepopulate-db
+deviceA insert/update/delete local SQLite records
+deviceA push changes to backend
+deviceB pull changes from backend
+deviceB applies pulled changes locally
+deviceB commit-sync
+```
+Expected result:
+```
+Device B inserted customer name: Inserted From Device A
+Device B updated customer city: Wroclaw
+Device B deleted customer is gone: 'customer-id'
+```
+
+## WiP: Automated Regression Tests with Testcontainers

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -1,51 +1,42 @@
 package com.ampliapps.amplisync.devclient;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
-import java.util.List;
 
 public class DevClientRunner {
     public static void main(String[] args) throws Exception {
-
         SyncDevClient client = new SyncDevClient("http://localhost:8080/ampli-sync/");
-        ObjectMapper objectMapper = new ObjectMapper();
 
-        String deviceA = "dev-client-device-a";
-        String deviceB = "dev-client-device-b";
+        String deviceAId = argumentOrDefault(args, 0, "dev-client-device-a");
+        String deviceBId = argumentOrDefault(args, 1, "dev-client-device-b");
 
-        Path deviceADirectory = Path.of("/tmp/ampli-sync-dev-client/device-a");
-        Path deviceBDirectory = Path.of("/tmp/ampli-sync-dev-client/device-b");
-
-        Path deviceAArchive = client.downloadPrepopulatedDatabaseArchive(deviceA, deviceADirectory);
-        Path deviceADatabasePath = client.unpackDatabaseArchive(deviceAArchive, deviceADirectory);
-
-        Path deviceBArchive = client.downloadPrepopulatedDatabaseArchive(deviceB, deviceBDirectory);
-        Path deviceBDatabasePath = client.unpackDatabaseArchive(deviceBArchive, deviceBDirectory);
-
-        try (SqliteDatabase deviceADatabase = SqliteDatabase.open(deviceADatabasePath);
-             SqliteDatabase deviceBDatabase = SqliteDatabase.open(deviceBDatabasePath)) {
-
-            PayloadBuilder deviceAPayloadBuilder = new PayloadBuilder(deviceADatabase);
+        try (SyncDevice deviceA = new SyncDevice(
+                client,
+                deviceAId,
+                Path.of("/tmp/ampli-sync-dev-client/device-a")
+        );
+             SyncDevice deviceB = new SyncDevice(
+                     client,
+                     deviceBId,
+                     Path.of("/tmp/ampli-sync-dev-client/device-b")
+             )) {
+            deviceA.prepopulate();
+            deviceB.prepopulate();
 
             String insertedCustomerId = UUID.randomUUID().toString();
+            String updatedCustomerId = "0b8e9b8e-0fb5-4f2d-8d4c-3c57e7dc8e47";
+            String deletedCustomerId = "8fb5f9c7-9929-4f87-8fcb-19f2092f0a5d";
 
-            Map<String, Object> insertedCustomer = Map.of(
+            deviceA.insertRow("demo_customers", Map.of(
                     "id", insertedCustomerId,
                     "name", "Inserted From Device A",
                     "email", "inserted-device-a@example.com",
                     "city", "Warsaw"
-            );
-
-            String updatedCustomerId = "0b8e9b8e-0fb5-4f2d-8d4c-3c57e7dc8e47";
-            String deletedCustomerId = "8fb5f9c7-9929-4f87-8fcb-19f2092f0a5d";
-
-            deviceADatabase.insertRow("demo_customers", insertedCustomer);
+            ));
             System.out.println("Device A inserted customer: " + insertedCustomerId);
 
-            deviceADatabase.updateRow(
+            deviceA.updateRow(
                     "demo_customers",
                     Map.of("city", "Wroclaw"),
                     "id",
@@ -53,35 +44,22 @@ public class DevClientRunner {
             );
             System.out.println("Device A updated customer: " + updatedCustomerId);
 
-            deviceADatabase.deleteRow("demo_customers", "id", deletedCustomerId);
+            deviceA.deleteRow("demo_customers", "id", deletedCustomerId);
             System.out.println("Device A deleted customer: " + deletedCustomerId);
 
-            PayloadBuildResult pushResult = deviceAPayloadBuilder.buildPushPayloadResult();
-
-            System.out.println("Device A push payload:");
-            System.out.println(objectMapper.writeValueAsString(pushResult.payload()));
-
-            client.sendChanges(deviceA, pushResult.payload());
+            deviceA.push();
             System.out.println("Device A pushed changes.");
 
-            deviceADatabase.clearProcessedChanges(pushResult);
-            System.out.println("Device A local markers cleared.");
+            deviceB.pullTable("demo_customers");
+            System.out.println("Device B pulled changes.");
 
-            List<PullChanges> deviceBPullChanges = client.pullChangesForTable("demo_customers", deviceB);
-
-            System.out.println("Device B pull response:");
-            System.out.println(objectMapper.writeValueAsString(deviceBPullChanges));
-
-            deviceBDatabase.applyPullChanges(deviceBPullChanges);
-            System.out.println("Device B applied pulled changes.");
-
-            String insertedCustomerNameOnB = deviceBDatabase.findFirstValue(
+            String insertedCustomerNameOnB = deviceB.findFirstValue(
                     "demo_customers",
                     "name",
                     "id = '" + insertedCustomerId + "'"
             );
 
-            String updatedCustomerCityOnB = deviceBDatabase.findFirstValue(
+            String updatedCustomerCityOnB = deviceB.findFirstValue(
                     "demo_customers",
                     "city",
                     "id = '" + updatedCustomerId + "'"
@@ -91,9 +69,9 @@ public class DevClientRunner {
             System.out.println("Device B updated customer city: " + updatedCustomerCityOnB);
 
             try {
-                deviceBDatabase.findFirstValue(
+                deviceB.findFirstValue(
                         "demo_customers",
-                        "id",
+                        "city",
                         "id = '" + deletedCustomerId + "'"
                 );
 
@@ -102,8 +80,10 @@ public class DevClientRunner {
                 System.out.println("Device B deleted customer is gone: " + deletedCustomerId);
             }
         }
-
-
     }
-}
 
+    private static String argumentOrDefault(String[] args, int index, String defaultValue) {
+        return args.length > index ? args[index] : defaultValue;
+    }
+
+}

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/DevClientRunner.java
@@ -56,13 +56,15 @@ public class DevClientRunner {
             String insertedCustomerNameOnB = deviceB.findFirstValue(
                     "demo_customers",
                     "name",
-                    "id = '" + insertedCustomerId + "'"
+                    "id",
+                    insertedCustomerId
             );
 
             String updatedCustomerCityOnB = deviceB.findFirstValue(
                     "demo_customers",
                     "city",
-                    "id = '" + updatedCustomerId + "'"
+                    "id",
+                    updatedCustomerId
             );
 
             System.out.println("Device B inserted customer name: " + insertedCustomerNameOnB);
@@ -72,7 +74,8 @@ public class DevClientRunner {
                 deviceB.findFirstValue(
                         "demo_customers",
                         "city",
-                        "id = '" + deletedCustomerId + "'"
+                        "id",
+                        deletedCustomerId
                 );
 
                 System.out.println("Device B deleted customer still exists: " + deletedCustomerId);

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -1,5 +1,6 @@
 package com.ampliapps.amplisync.devclient;
 
+import javax.xml.transform.Result;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -395,16 +396,19 @@ public class SqliteDatabase implements AutoCloseable {
     }
 
 
-    public String findFirstValue(String tableName, String columnName, String whereClause) {
-        String sql = "select " + columnName + " from " + tableName + " where " + whereClause + " limit 1";
+    public String findFirstValue(String tableName, String columnName, String whereColumn, Object whereValue) {
+        String sql = "select " + columnName + " from " + tableName + " where " + whereColumn + " = ? limit 1";
 
-        try (Statement statement = connection.createStatement();
-             ResultSet resultSet = statement.executeQuery(sql)) {
-            if (!resultSet.next()) {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+             statement.setObject(1, whereValue);
+
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (resultSet.next()) {
+                    return resultSet.getString(columnName);
+                }
+
                 throw new IllegalStateException("No row found in table: " + tableName);
             }
-
-            return resultSet.getString(columnName);
         } catch (SQLException e) {
             throw new IllegalStateException("Failed to find first value in table: " + tableName, e);
         }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -167,6 +167,32 @@ public class SyncDevClient {
         }
     }
 
+    public void commitSync(int syncId) {
+        if (syncId <= 0) {
+            return;
+        }
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(syncBaseUrl + "commit-sync/" + syncId))
+                .header("Authorization", DEV_AUTH_HEADER)
+                .GET()
+                .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IllegalStateException("Commit sync failed with status: " + response.statusCode());
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Commit sync request failed", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Commit sync request was interrupted", e);
+        }
+    }
+
+
 
     private static String unzipGzip(byte[] compressedBytes) throws IOException {
         try (GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(compressedBytes))) {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
@@ -1,0 +1,92 @@
+package com.ampliapps.amplisync.devclient;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents one local sync device.
+ * Each device has its own id, working directory and local SQLite database.
+ * This class wraps lower level http and db operations into steps:
+ * prepopulate, local changes(insert, update, delete), push and pull.
+ */
+
+public class SyncDevice implements AutoCloseable {
+    private final SyncDevClient client;
+    private final String deviceId;
+    private final Path workDirectory;
+    private SqliteDatabase database;
+
+    public SyncDevice(SyncDevClient client, String deviceId, Path workDirectory) {
+        this.client = client;
+        this.deviceId = deviceId;
+        this.workDirectory = workDirectory;
+    }
+
+    public void prepopulate() {
+        Path archivePath = client.downloadPrepopulatedDatabaseArchive(deviceId, workDirectory);
+        Path databasePath = client.unpackDatabaseArchive(archivePath, workDirectory);
+        database = SqliteDatabase.open(databasePath);
+    }
+
+    public void insertRow(String tableName, Map<String, Object> values) {
+        requireDatabase();
+        database.insertRow(tableName, values);
+    }
+
+    public void updateRow(String tableName, Map<String, Object> values, String whereColumn, Object whereValue) {
+        requireDatabase();
+        database.updateRow(tableName, values, whereColumn, whereValue);
+    }
+
+    public void deleteRow(String tableName, String whereColumn, Object whereValue) {
+        requireDatabase();
+        database.deleteRow(tableName, whereColumn, whereValue);
+    }
+
+    public void push() {
+        requireDatabase();
+
+        PayloadBuilder payloadBuilder = new PayloadBuilder(database);
+        PayloadBuildResult result = payloadBuilder.buildPushPayloadResult();
+
+        client.sendChanges(deviceId, result.payload());
+        database.clearProcessedChanges(result);
+    }
+
+    /**
+     * Pulls changes for one table, applies them locally, and confirms with commitSync on backend.
+     */
+    public void pullTable(String tableName) {
+        requireDatabase();
+
+        List<PullChanges> changes = client.pullChangesForTable(tableName, deviceId);
+        database.applyPullChanges(changes);
+
+        for (PullChanges change : changes) {
+            client.commitSync(change.syncId());
+        }
+    }
+
+    public String findFirstValue(String tableName, String columnName, String whereClause) {
+        requireDatabase();
+        return database.findFirstValue(tableName, columnName, whereClause);
+    }
+
+    public String deviceId() {
+        return deviceId;
+    }
+
+    private void requireDatabase() {
+        if (database == null) {
+            throw new IllegalStateException("Device database is not initialized. Call prepopulate() first.");
+        }
+    }
+
+    @Override
+    public void close() {
+        if (database != null) {
+            database.close();
+        }
+    }
+}

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
@@ -68,9 +68,9 @@ public class SyncDevice implements AutoCloseable {
         }
     }
 
-    public String findFirstValue(String tableName, String columnName, String whereClause) {
+    public String findFirstValue(String tableName, String columnName, String whereColumn, Object whereValue) {
         requireDatabase();
-        return database.findFirstValue(tableName, columnName, whereClause);
+        return database.findFirstValue(tableName, columnName, whereColumn, whereValue);
     }
 
     public String deviceId() {


### PR DESCRIPTION
## Summary

This PR is stacked on top of the pull flow PR. Please review  it first: https://github.com/AMPLIFIER-sp-z-o-o/ampli-sync/pull/106

Adds `commitSync()` request, and adds a higher-level `SyncDevice` wrapper.
It keeps the lower level http  and sqlite logic in `SyncDevClient` / `SqliteDatabase`, andmakes future test scenarios easier to write and read.

## Included

- added `commitSync()` request
- added `SyncDevice`
- simplified `DevClientRunner` to use `SyncDevice`
- added command-line device ids 

## Current flow

```text
deviceA prepopulate
deviceB prepopulate
deviceA local insert/update/delete
deviceA push
deviceB pullTable
deviceB apply changes locally
deviceB commit-sync
verify deviceB local SQLite 
```
## Tested

- manual DevClientRunner with local Docker backend

## Next PR

I want to add dev user selection for the dev client, and  first Testcontainers regression tests.

  Currently, local Docker backend runs with `AUTH_DISABLED=true` and uses one fixed `DEV_USER_ID`. That is not enough for testing multiple users or tenants.

  The plan is to add a  header, for example `Dev-User-Id`, which would be used only when `AUTH_DISABLED=true`. Then the dev client could create scenarios for different users

