### PR TITLE
Feature/dev client regression tests

### DIFF
--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -170,6 +170,30 @@ public class SqliteDatabase implements AutoCloseable {
         }
     }
 
+    public List<Map<String, Object>> findRows(String tableName) {
+        String sql = "select * from " + tableName;
+
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(sql)) {
+            return toRows(resultSet);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to read rows: " + tableName);
+        }
+    }
+
+    public List<Map<String, Object>> findRows(String tableName, String whereColumn, Object whereValue) {
+        String sql = "select * from " + tableName + " where " + whereColumn + " = ? limit 1";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+
+            statement.setObject(1, whereValue);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return toRows(resultSet);
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to read rows: " + tableName, e);
+        }
+    }
+
     private static List<Map<String, Object>> toRows(ResultSet resultSet) throws SQLException {
         List<Map<String, Object>> rows = new ArrayList<>();
         ResultSetMetaData metaData = resultSet.getMetaData();

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -177,12 +177,12 @@ public class SqliteDatabase implements AutoCloseable {
              ResultSet resultSet = statement.executeQuery(sql)) {
             return toRows(resultSet);
         } catch (SQLException e) {
-            throw new IllegalStateException("Failed to read rows: " + tableName);
+            throw new IllegalStateException("Failed to read rows: " + tableName, e);
         }
     }
 
     public List<Map<String, Object>> findRows(String tableName, String whereColumn, Object whereValue) {
-        String sql = "select * from " + tableName + " where " + whereColumn + " = ? limit 1";
+        String sql = "select * from " + tableName + " where " + whereColumn + " = ?";
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
 
             statement.setObject(1, whereValue);

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -1,6 +1,5 @@
 package com.ampliapps.amplisync.devclient;
 
-import javax.xml.transform.Result;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -8,7 +7,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.UUID;
 import java.sql.ResultSetMetaData;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -215,7 +213,7 @@ public class SqliteDatabase implements AutoCloseable {
                 return resultSet.getInt(1);
             }
         } catch (SQLException e) {
-            throw new IllegalStateException("Faled to count rows: " + tableName, e);
+            throw new IllegalStateException("Failed to count rows: " + tableName, e);
         }
 
     }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -151,6 +151,25 @@ public class SqliteDatabase implements AutoCloseable {
         }
     }
 
+    public Map<String, Object> findRow(String tableName, String whereColumn, Object whereValue) {
+        String sql = "select * from " + tableName + " where " + whereColumn + " = ? limit 1";
+
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, whereValue);
+            try(ResultSet resultSet = statement.executeQuery()) {
+                List<Map<String, Object>> rows = toRows(resultSet);
+
+                if (rows.isEmpty()) {
+                    throw new IllegalStateException("No row found in table: " + tableName);
+                }
+
+                return rows.get(0);
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to find row in table: " + tableName, e);
+        }
+    }
+
     private static List<Map<String, Object>> toRows(ResultSet resultSet) throws SQLException {
         List<Map<String, Object>> rows = new ArrayList<>();
         ResultSetMetaData metaData = resultSet.getMetaData();

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SqliteDatabase.java
@@ -194,6 +194,32 @@ public class SqliteDatabase implements AutoCloseable {
         }
     }
 
+    public int countRows(String tableName) {
+        String sql = "select count(*) from " + tableName;
+
+        try (Statement statement = connection.createStatement();
+            ResultSet resultSet = statement.executeQuery(sql)) {
+            resultSet.next();
+            return resultSet.getInt(1);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to count rows: " + tableName, e);
+        }
+    }
+
+    public int countRows(String tableName, String whereColumn, Object whereValue) {
+        String sql = "select count(*) from " + tableName + " where " + whereColumn + " = ?";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setObject(1, whereValue);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                resultSet.next();
+                return resultSet.getInt(1);
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Faled to count rows: " + tableName, e);
+        }
+
+    }
+
     private static List<Map<String, Object>> toRows(ResultSet resultSet) throws SQLException {
         List<Map<String, Object>> rows = new ArrayList<>();
         ResultSetMetaData metaData = resultSet.getMetaData();

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+
 /**
  * Represents one local sync device.
  * Each device has its own id, working directory and local SQLite database.
@@ -76,6 +77,11 @@ public class SyncDevice implements AutoCloseable {
     public boolean rowExists(String tableName, String whereColumn, Object whereValue) {
         requireDatabase();
         return database.rowExists(tableName, whereColumn, whereValue);
+    }
+
+    public Map<String, Object> findRow(String tableName, String whereColumn, Object whereValue) {
+        requireDatabase();
+        return database.findRow(tableName, whereColumn, whereValue);
     }
 
     public String deviceId() {

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
@@ -104,6 +104,15 @@ public class SyncDevice implements AutoCloseable {
         return database.countRows(tableName, whereColumn, whereValue);
     }
 
+    public boolean hasLocalChanges() {
+        requireDatabase();
+
+        PayloadBuilder.PushPayload payload = new PayloadBuilder(database).buildPushPayload();
+
+        return !payload.changes().isEmpty() || !payload.deletes().isEmpty();
+    }
+
+
     public String deviceId() {
         return deviceId;
     }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
@@ -94,6 +94,16 @@ public class SyncDevice implements AutoCloseable {
         return database.findRows(tableName, whereColumn, whereValue);
     }
 
+    public int countRows(String tableName) {
+        requireDatabase();
+        return database.countRows(tableName);
+    }
+
+    public int countRows(String tableName, String whereColumn, Object whereValue) {
+        requireDatabase();
+        return database.countRows(tableName, whereColumn, whereValue);
+    }
+
     public String deviceId() {
         return deviceId;
     }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
@@ -112,6 +112,18 @@ public class SyncDevice implements AutoCloseable {
         return !payload.changes().isEmpty() || !payload.deletes().isEmpty();
     }
 
+    public boolean hasPendingUpdateOrDeleteMarkers() {
+        requireDatabase();
+
+        for (String tableName : database.findSynchronizedTables()) {
+            if (!database.findRowsWithMergeUpdate(tableName).isEmpty()) {
+                return true;
+            }
+        }
+
+        return !database.findDeletedRecords().isEmpty();
+    }
+
 
     public String deviceId() {
         return deviceId;

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
@@ -107,10 +107,19 @@ public class SyncDevice implements AutoCloseable {
     public boolean hasLocalChanges() {
         requireDatabase();
 
-        PayloadBuilder.PushPayload payload = new PayloadBuilder(database).buildPushPayload();
+        for (String tableName : database.findSynchronizedTables()) {
+            if (!database.findRowsWithNullRowId(tableName).isEmpty()) {
+                return true;
+            }
 
-        return !payload.changes().isEmpty() || !payload.deletes().isEmpty();
+            if (!database.findRowsWithMergeUpdate(tableName).isEmpty()) {
+                return true;
+            }
+        }
+
+        return !database.findDeletedRecords().isEmpty();
     }
+
 
     public boolean hasPendingUpdateOrDeleteMarkers() {
         requireDatabase();

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevice.java
@@ -84,6 +84,16 @@ public class SyncDevice implements AutoCloseable {
         return database.findRow(tableName, whereColumn, whereValue);
     }
 
+    public List<Map<String, Object>> findRows(String tableName) {
+        requireDatabase();
+        return database.findRows(tableName);
+    }
+
+    public List<Map<String, Object>> findRows(String tableName, String whereColumn, Object whereValue) {
+        requireDatabase();
+        return database.findRows(tableName, whereColumn, whereValue);
+    }
+
     public String deviceId() {
         return deviceId;
     }

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/DemoCustomers.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/DemoCustomers.java
@@ -1,0 +1,36 @@
+package com.ampliapps.amplisync.devclient;
+
+import java.util.Map;
+
+public class DemoCustomers {
+    static final String TABLE = "demo_customers";
+
+    static final String UPDATED_CUSTOMER_ID = "0b8e9b8e-0fb5-4f2d-8d4c-3c57e7dc8e47";
+    static final String DELETED_CUSTOMER_ID = "8fb5f9c7-9929-4f87-8fcb-19f2092f0a5d";
+
+    static Map<String, Object> insertedCustomer(String id) {
+        return Map.of(
+                "id", id,
+                "name", "Inserted From Device A",
+                "email", "inserted-device-a@example.com",
+                "city", "Warsaw"
+        );
+    }
+
+    static Map<String, Object> updatedCustomerValues() {
+        return Map.of(
+                "city", "Wroclaw"
+        );
+    }
+
+    static Map<String, Object> expectedUpdatedCustomer() {
+        return Map.of(
+                "id", UPDATED_CUSTOMER_ID,
+                "name", "North Coast Shop",
+                "email", "hello@northcoast.example",
+                "city", "Wroclaw"
+        );
+    }
+
+}
+

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/DemoCustomersFixture.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/DemoCustomersFixture.java
@@ -2,7 +2,7 @@ package com.ampliapps.amplisync.devclient;
 
 import java.util.Map;
 
-public class DemoCustomers {
+public class DemoCustomersFixture {
     static final String TABLE = "demo_customers";
 
     static final String UPDATED_CUSTOMER_ID = "0b8e9b8e-0fb5-4f2d-8d4c-3c57e7dc8e47";

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceAssertions.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceAssertions.java
@@ -33,8 +33,19 @@ public class SyncDeviceAssertions {
             String whereColumn,
             Object whereValue
     ) {
-        assertFalse(device.rowExists(tableName, whereColumn, whereValue));
-        assertEquals(0, device.countRows(tableName, whereColumn, whereValue));
+        assertFalse(
+                device.rowExists(tableName, whereColumn, whereValue),
+                "Expected no row in table " + tableName
+                        + " where " + whereColumn + " = " + whereValue
+        );
+
+        assertEquals(
+                0,
+                device.countRows(tableName, whereColumn, whereValue),
+                "Expected zero rows in table " + tableName
+                        + " where " + whereColumn + " = " + whereValue
+        );
+
     }
 
 

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceAssertions.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceAssertions.java
@@ -45,4 +45,12 @@ public class SyncDeviceAssertions {
     static void assertNoLocalChanges(SyncDevice device) {
         assertFalse(device.hasLocalChanges(), "Device has local pending sync changes");
     }
+
+    static void assertNoPendingUpdateOrDeleteMarkers(SyncDevice device) {
+        assertFalse(
+                device.hasPendingUpdateOrDeleteMarkers(),
+                "Device has pending update/delete sync markers"
+        );
+    }
+
 }

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceAssertions.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceAssertions.java
@@ -10,10 +10,11 @@ public class SyncDeviceAssertions {
     static void assertRowValues(
             SyncDevice device,
             String tableName,
-            String id,
+            String whereColumn,
+            Object whereValue,
             Map<String, Object> expectedValues
     ) {
-        Map<String, Object> row = device.findRow(tableName, "id", id);
+        Map<String, Object> row = device.findRow(tableName, whereColumn, whereValue);
 
         for (Map.Entry<String, Object> expectedValue : expectedValues.entrySet()) {
             String columnName = expectedValue.getKey();
@@ -26,10 +27,16 @@ public class SyncDeviceAssertions {
         }
     }
 
-    static void assertRowDoesNotExist(SyncDevice device, String tableName, String id) {
-        assertFalse(device.rowExists(tableName, "id", id));
-        assertEquals(0, device.countRows(tableName, "id", id));
+    static void assertRowDoesNotExist(
+            SyncDevice device,
+            String tableName,
+            String whereColumn,
+            Object whereValue
+    ) {
+        assertFalse(device.rowExists(tableName, whereColumn, whereValue));
+        assertEquals(0, device.countRows(tableName, whereColumn, whereValue));
     }
+
 
     static void assertRowsCount(SyncDevice device, String tableName, int expectedCount) {
         assertEquals(expectedCount, device.countRows(tableName));

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceAssertions.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceAssertions.java
@@ -1,0 +1,29 @@
+package com.ampliapps.amplisync.devclient;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class SyncDeviceAssertions {
+    static void assertRowValues(
+            SyncDevice device,
+            String tableName,
+            String id,
+            Map<String, Object> expectedValues
+    ) {
+        Map<String, Object> row = device.findRow(tableName, "id", id);
+
+        for(Map.Entry<String, Object> expectedValue: expectedValues.entrySet()) {
+            String columnName = expectedValue.getKey();
+            assertTrue(row.containsKey(columnName), "Missing column: " + columnName);
+            assertEquals(expectedValue.getValue(), row.get(columnName));
+        }
+    }
+
+    static void assertRowDoesNotExist(SyncDevice device, String tableName, String id) {
+        assertFalse(device.rowExists(tableName, "id", id));
+        assertEquals(0, device.countRows(tableName, "id", id));
+    }
+}

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceAssertions.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceAssertions.java
@@ -2,9 +2,9 @@ package com.ampliapps.amplisync.devclient;
 
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SyncDeviceAssertions {
     static void assertRowValues(
@@ -15,15 +15,27 @@ public class SyncDeviceAssertions {
     ) {
         Map<String, Object> row = device.findRow(tableName, "id", id);
 
-        for(Map.Entry<String, Object> expectedValue: expectedValues.entrySet()) {
+        for (Map.Entry<String, Object> expectedValue : expectedValues.entrySet()) {
             String columnName = expectedValue.getKey();
             assertTrue(row.containsKey(columnName), "Missing column: " + columnName);
-            assertEquals(expectedValue.getValue(), row.get(columnName));
+            assertEquals(
+                    expectedValue.getValue(),
+                    row.get(columnName),
+                    "Wrong value for column: " + columnName
+            );
         }
     }
 
     static void assertRowDoesNotExist(SyncDevice device, String tableName, String id) {
         assertFalse(device.rowExists(tableName, "id", id));
         assertEquals(0, device.countRows(tableName, "id", id));
+    }
+
+    static void assertRowsCount(SyncDevice device, String tableName, int expectedCount) {
+        assertEquals(expectedCount, device.countRows(tableName));
+    }
+
+    static void assertNoLocalChanges(SyncDevice device) {
+        assertFalse(device.hasLocalChanges(), "Device has local pending sync changes");
     }
 }

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -46,37 +46,54 @@ class SyncDeviceRegressionTest {
             deviceA.prepopulate();
             deviceB.prepopulate();
 
+            SyncDeviceAssertions.assertNoLocalChanges(deviceA);
+            SyncDeviceAssertions.assertNoLocalChanges(deviceB);
+
             String insertedCustomerId = UUID.randomUUID().toString();
-            String updatedCustomerId = "0b8e9b8e-0fb5-4f2d-8d4c-3c57e7dc8e47";
-            String deletedCustomerId = "8fb5f9c7-9929-4f87-8fcb-19f2092f0a5d";
+            Map<String, Object> insertedCustomer = DemoCustomers.insertedCustomer(insertedCustomerId);
 
-            deviceA.insertRow("demo_customers", Map.of(
-                    "id", insertedCustomerId,
-                    "name", "Inserted From Device A",
-                    "email", "inserted-device-a@example.com",
-                    "city", "Warsaw"
-            ));
-
-            deviceA.updateRow("demo_customers", Map.of("city", "Wroclaw"), "id", updatedCustomerId);
-            deviceA.deleteRow("demo_customers", "id", deletedCustomerId);
+            deviceA.insertRow(DemoCustomers.TABLE, insertedCustomer);
+            deviceA.updateRow(
+                    DemoCustomers.TABLE,
+                    DemoCustomers.updatedCustomerValues(),
+                    "id",
+                    DemoCustomers.UPDATED_CUSTOMER_ID
+            );
+            deviceA.deleteRow(DemoCustomers.TABLE, "id", DemoCustomers.DELETED_CUSTOMER_ID);
 
             deviceA.push();
-            deviceB.pullTable("demo_customers");
 
-            Map<String, Object> insertedCustomerOnB = deviceB.findRow("demo_customers", "id", insertedCustomerId);
-            assertEquals("Inserted From Device A", insertedCustomerOnB.get("name"));
-            assertEquals("inserted-device-a@example.com", insertedCustomerOnB.get("email"));
-            assertEquals("Warsaw", insertedCustomerOnB.get("city"));
-            assertEquals(1, deviceB.countRows("demo_customers", "id", insertedCustomerId));
+            SyncDeviceAssertions.assertNoLocalChanges(deviceA);
 
-            Map<String, Object> updatedCustomerOnB = deviceB.findRow("demo_customers", "id", updatedCustomerId);
-            assertEquals("Wroclaw", updatedCustomerOnB.get("city"));
-            assertEquals("North Coast Shop", updatedCustomerOnB.get("name"));
+            deviceB.pullTable(DemoCustomers.TABLE);
 
-            assertFalse(deviceB.rowExists("demo_customers", "id", deletedCustomerId));
-            assertEquals(0, deviceB.countRows("demo_customers", "id", deletedCustomerId));
+            SyncDeviceAssertions.assertRowValues(
+                    deviceB,
+                    DemoCustomers.TABLE,
+                    "id",
+                    insertedCustomerId,
+                    insertedCustomer
+            );
 
+            SyncDeviceAssertions.assertRowValues(
+                    deviceB,
+                    DemoCustomers.TABLE,
+                    "id",
+                    DemoCustomers.UPDATED_CUSTOMER_ID,
+                    DemoCustomers.expectedUpdatedCustomer()
+            );
+
+            SyncDeviceAssertions.assertRowDoesNotExist(
+                    deviceB,
+                    DemoCustomers.TABLE,
+                    "id",
+                    DemoCustomers.DELETED_CUSTOMER_ID
+            );
+
+            SyncDeviceAssertions.assertNoLocalChanges(deviceB);
         }
     }
+
+
 
 }

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -63,7 +63,7 @@ class SyncDeviceRegressionTest {
 
             deviceA.push();
 
-            SyncDeviceAssertions.assertNoLocalChanges(deviceA);
+            SyncDeviceAssertions.assertNoPendingUpdateOrDeleteMarkers(deviceA);
 
             deviceB.pullTable(DemoCustomers.TABLE);
 

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -63,12 +63,19 @@ class SyncDeviceRegressionTest {
             deviceA.push();
             deviceB.pullTable("demo_customers");
 
-            assertEquals("Inserted From Device A",
-                    deviceB.findFirstValue("demo_customers", "name", "id", insertedCustomerId));
+            Map<String, Object> insertedCustomerOnB = deviceB.findRow("demo_customers", "id", insertedCustomerId);
+            assertEquals("Inserted From Device A", insertedCustomerOnB.get("name"));
+            assertEquals("inserted-device-a@example.com", insertedCustomerOnB.get("email"));
+            assertEquals("Warsaw", insertedCustomerOnB.get("city"));
+            assertEquals(1, deviceB.countRows("demo_customers", "id", insertedCustomerId));
 
-            assertEquals("Wroclaw",
-                    deviceB.findFirstValue("demo_customers", "city", "id", updatedCustomerId));
+            Map<String, Object> updatedCustomerOnB = deviceB.findRow("demo_customers", "id", updatedCustomerId);
+            assertEquals("Wroclaw", updatedCustomerOnB.get("city"));
+            assertEquals("North Coast Shop", updatedCustomerOnB.get("name"));
+
             assertFalse(deviceB.rowExists("demo_customers", "id", deletedCustomerId));
+            assertEquals(0, deviceB.countRows("demo_customers", "id", deletedCustomerId));
+
         }
     }
 

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -41,6 +41,7 @@ class SyncDeviceRegressionTest {
         try (SyncDevice deviceA = new SyncDevice(client, "test-device-a", Path.of("target/test-devices/device-a"));
              SyncDevice deviceB = new SyncDevice(client, "test-device-b", Path.of("target/test-devices/device-b"))) {
 
+            // Arrange: create two local devices for the same dev user.
             deviceA.prepopulate();
             deviceB.prepopulate();
 
@@ -59,6 +60,7 @@ class SyncDeviceRegressionTest {
             );
             deviceA.deleteRow(DemoCustomersFixture.TABLE, "id", DemoCustomersFixture.DELETED_CUSTOMER_ID);
 
+            // Act: push device A changes and pull backend
             deviceA.push();
 
             SyncDeviceAssertions.assertNoPendingUpdateOrDeleteMarkers(deviceA);
@@ -68,6 +70,7 @@ class SyncDeviceRegressionTest {
 
             deviceB.pullTable(DemoCustomersFixture.TABLE);
 
+            // Assert: device B local SQLite has the expected synced state.
             SyncDeviceAssertions.assertRowValues(
                     deviceB,
                     DemoCustomersFixture.TABLE,
@@ -94,5 +97,19 @@ class SyncDeviceRegressionTest {
             SyncDeviceAssertions.assertNoLocalChanges(deviceB);
         }
     }
+
+    @Test
+    void shouldResolveSimultaneousUpdateScenario() {
+        // Arrange: create two local devices for the same dev user.
+
+        // Act: device A updates the record and pushes.
+
+        // Act: device B updates the same record and pushes.
+
+        // Act: both devices pull backend state.
+
+        // Assert: local SQLite state matches expected conflict behavior.
+    }
+
 
 }

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -9,8 +9,6 @@ import java.nio.file.Path;
 import java.io.File;
 import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @Testcontainers
 class SyncDeviceRegressionTest {
@@ -50,26 +48,29 @@ class SyncDeviceRegressionTest {
             SyncDeviceAssertions.assertNoLocalChanges(deviceB);
 
             String insertedCustomerId = UUID.randomUUID().toString();
-            Map<String, Object> insertedCustomer = DemoCustomers.insertedCustomer(insertedCustomerId);
+            Map<String, Object> insertedCustomer = DemoCustomersFixture.insertedCustomer(insertedCustomerId);
 
-            deviceA.insertRow(DemoCustomers.TABLE, insertedCustomer);
+            deviceA.insertRow(DemoCustomersFixture.TABLE, insertedCustomer);
             deviceA.updateRow(
-                    DemoCustomers.TABLE,
-                    DemoCustomers.updatedCustomerValues(),
+                    DemoCustomersFixture.TABLE,
+                    DemoCustomersFixture.updatedCustomerValues(),
                     "id",
-                    DemoCustomers.UPDATED_CUSTOMER_ID
+                    DemoCustomersFixture.UPDATED_CUSTOMER_ID
             );
-            deviceA.deleteRow(DemoCustomers.TABLE, "id", DemoCustomers.DELETED_CUSTOMER_ID);
+            deviceA.deleteRow(DemoCustomersFixture.TABLE, "id", DemoCustomersFixture.DELETED_CUSTOMER_ID);
 
             deviceA.push();
 
             SyncDeviceAssertions.assertNoPendingUpdateOrDeleteMarkers(deviceA);
 
-            deviceB.pullTable(DemoCustomers.TABLE);
+            deviceA.pullTable(DemoCustomersFixture.TABLE);
+            SyncDeviceAssertions.assertNoLocalChanges(deviceA);
+
+            deviceB.pullTable(DemoCustomersFixture.TABLE);
 
             SyncDeviceAssertions.assertRowValues(
                     deviceB,
-                    DemoCustomers.TABLE,
+                    DemoCustomersFixture.TABLE,
                     "id",
                     insertedCustomerId,
                     insertedCustomer
@@ -77,23 +78,21 @@ class SyncDeviceRegressionTest {
 
             SyncDeviceAssertions.assertRowValues(
                     deviceB,
-                    DemoCustomers.TABLE,
+                    DemoCustomersFixture.TABLE,
                     "id",
-                    DemoCustomers.UPDATED_CUSTOMER_ID,
-                    DemoCustomers.expectedUpdatedCustomer()
+                    DemoCustomersFixture.UPDATED_CUSTOMER_ID,
+                    DemoCustomersFixture.expectedUpdatedCustomer()
             );
 
             SyncDeviceAssertions.assertRowDoesNotExist(
                     deviceB,
-                    DemoCustomers.TABLE,
+                    DemoCustomersFixture.TABLE,
                     "id",
-                    DemoCustomers.DELETED_CUSTOMER_ID
+                    DemoCustomersFixture.DELETED_CUSTOMER_ID
             );
 
             SyncDeviceAssertions.assertNoLocalChanges(deviceB);
         }
     }
-
-
 
 }


### PR DESCRIPTION
## Summary

Adds helper methods and assertions for writing dev client regression scenarios.

This PR improves the dev client API, so that e2e tests can check local sqlite state more directly and keep scenario code easier to read/write

## Included

- added row lookup helpers in `SqliteDatabase` and `SyncDevice`
- added row count helpers
- added local change marker checks
- added reusable `SyncDeviceAssertions`
- added `DemoCustomersFixture` for demo customer test data
- updated the two-device regression test to use fixtures and assertions
- clarified the test flow with Arrange / Act / Assert comments

## Test flow

 ```text
deviceA prepopulate-db
deviceB prepopulate-db
deviceA insert/update/delete local SQLite records
deviceA push changes to backend
deviceA pull backend (to get inserted row id)
deviceB pull changes from backend
assert deviceA has no local pending changes
assert deviceB has inserted/updated/deleted state
```
## Not Included (next PR)

- PostgreSQL assertions after push
- more scenarios

## Tested

- mvn test

mvn test requires Docker/Testcontainers.

  
