### PR TITLE
Refactor - backend cleanup prep

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/InvalidTokenException.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/InvalidTokenException.java
@@ -1,9 +1,0 @@
-package com.ampliapps.amplisync;
-
-import javax.naming.AuthenticationException;
-
-public class InvalidTokenException extends AuthenticationException {
-    public InvalidTokenException(String message) {
-        super(message);
-    }
-}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/BinaryWriter.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/BinaryWriter.java
@@ -1,6 +1,5 @@
 package com.ampliapps.amplisync.SyncServer.Synchronization;
 
-import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -17,8 +16,7 @@ public class BinaryWriter {
         Boolean append = false;
 
         try {
-            if (!file.exists() || !append) out = new ObjectOutputStream(new FileOutputStream(filename));
-            else out = new AppendableObjectOutputStream(new FileOutputStream(filename, append));
+            out = new ObjectOutputStream(new FileOutputStream(filename));
             out.writeObject(obj);
             out.flush();
         } catch (Exception e) {
@@ -53,15 +51,5 @@ public class BinaryWriter {
             }
         }
         return null;
-    }
-
-    private class AppendableObjectOutputStream extends ObjectOutputStream {
-        public AppendableObjectOutputStream(OutputStream out) throws IOException {
-            super(out);
-        }
-
-        @Override
-        protected void writeStreamHeader() throws IOException {
-        }
     }
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/DatabaseTableParameter.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/DatabaseTableParameter.java
@@ -6,5 +6,4 @@ public class DatabaseTableParameter
     public String DbType;
     public Boolean IsNullable;
     public Integer ParameterOrder = 1;
-    public Object ParameterValue = null;
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
@@ -156,7 +156,7 @@ public class SQLitePrepopulate {
                 Logs.write(Logs.Level.INFO, "PrepopulateDatabase->table "+ subscriberUUID +"/" + reader.getString("TableName"));
                 tablePackageCount = 1;
                 String tableFilter = reader.getString("TableFilter");
-                EnumarateChanges(reader.getString("TableId"), subscriberId, reader.getString("TableName"), tableSchema, tableFilter, subscriberUUID);
+                EnumerateChanges(reader.getString("TableId"), subscriberId, reader.getString("TableName"), tableSchema, tableFilter, subscriberUUID);
                 Logs.write(Logs.Level.INFO, "PrepopulateDatabase->table " + subscriberUUID + "/" + reader.getString("TableName") + " done");
             } else
                 Logs.write(Logs.Level.TRACE, "DoSync(). Table " + userSchema + "." + table + " was not found in MergeTablesToSync.");
@@ -169,7 +169,7 @@ public class SQLitePrepopulate {
         }
     }
 
-    private void EnumarateChanges(String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
+    private void EnumerateChanges(String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
         SyncService syncService = new SyncService();
 
         String filterVW = tableSchema + "." + tableName;
@@ -293,7 +293,7 @@ public class SQLitePrepopulate {
                         }
 
                     } catch (Exception e) {
-                        Logs.write(Logs.Level.ERROR, "EnumarateChanges()->record iterate: "+ tableName+". " + e.getMessage());
+                        Logs.write(Logs.Level.ERROR, "EnumerateChanges()->record iterate: "+ tableName+". " + e.getMessage());
                     }
                 }
 
@@ -322,12 +322,12 @@ public class SQLitePrepopulate {
             Integer syncId = syncService.StartNewSync(subscriberId, Integer.parseInt(tableId), tableSchema);
             syncService.CommitSync(syncId.toString(), tableSchema);
         } catch (SQLException e) {
-            Logs.write(Logs.Level.ERROR, "EnumarateChanges(): " + tableName + ". " + e.getMessage());
+            Logs.write(Logs.Level.ERROR, "EnumerateChanges(): " + tableName + ". " + e.getMessage());
         }
         finally {
             JDBCCloser.close(cn);
             if(tablesData.size() > 0 && tablesData.size() == 5000 && tablePackageCount < 13) {
-                EnumarateChanges(tableId, subscriberId, tableName, tableSchema, tableFilter, subscriberUUID);
+                EnumerateChanges(tableId, subscriberId, tableName, tableSchema, tableFilter, subscriberUUID);
             }
         }
     }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Stopwatch;
-import com.google.common.cache.LoadingCache;
 import org.postgresql.util.PGobject;
 
 import javax.sql.rowset.CachedRowSet;
@@ -33,7 +32,6 @@ import java.util.regex.Pattern;
 
 public class SyncService {
 
-    private static LoadingCache<String, String> tableSchemaCache = null;
     public Integer syncIdForTestPurpose = -1;
     List<DataObject> dataToSync = new ArrayList<>();
     private final SQLQueries QUERIES = new SQLQueries();

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -212,7 +212,7 @@ public class SyncService {
                         root.set("inserts", inserts);
 
                     } catch (Exception e) {
-                        Logs.write(Logs.Level.ERROR, "EnumarateChanges() " + e.getMessage());
+                        Logs.write(Logs.Level.ERROR, "EnumerateChanges() " + e.getMessage());
                     }
                 }
 
@@ -221,7 +221,7 @@ public class SyncService {
             } while (hasResults || cmd.getUpdateCount() != -1);
 
         } catch (SQLException e) {
-            Logs.write(Logs.Level.ERROR, "EnumarateChanges() " + e.getMessage());
+            Logs.write(Logs.Level.ERROR, "EnumerateChanges() " + e.getMessage());
         } finally {
             JDBCCloser.close(cn);
         }


### PR DESCRIPTION
# Description
This PR contains a small backend cleanup, before the sync-compressed endpoint flow refactor.

It removes unused code and fixes minor naming/spelling issues 

Changes:
- removed unused authentication exception,
- removed unused SyncService cache field,
- removed unused BinaryWriter path,
- removed unused DatabaseTableParameter value field,
- fixed enumeration spelling.

