### PR TITLE
Refactor sync-compressed backend flow

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullQueryBuilder.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullQueryBuilder.java
@@ -3,7 +3,7 @@ package com.ampliapps.amplisync.SyncServer.Synchronization;
 import com.ampliapps.amplisync.SQLiteSyncConfig;
 
 public class PullQueryBuilder {
-    public StringBuilder buildInsertChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscirberUUID) {
+    public StringBuilder buildInsertChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscriberUUID) {
         StringBuilder query = new StringBuilder();
         String topLimit = "";
         if (SQLiteSyncConfig.PACKAGE_SIZE != null && !SQLiteSyncConfig.PACKAGE_SIZE.isEmpty())
@@ -23,7 +23,7 @@ public class PullQueryBuilder {
         query.append("not exists (select 1 from  " + tableSchema + ".MergeContent_" + tableName + " t where vw.rowid=t.rowid and t.SubscriberId=" + subscriberId + ") ");
         if(!filterVW.startsWith(tableSchema + ".fn_") && !filterVW.startsWith("fn_"))
             if(filterVW_CD.trim().length() > 0)
-                query.append("and vw.uniquename='"+subscirberUUID+"'");
+                query.append("and vw.uniquename='"+subscriberUUID+"'");
         query.append(" " + topLimit + "");
         query.append(") inserts on tb.rowid = inserts.rowid ");
         if(tableName.equalsIgnoreCase("mergeidentity"))
@@ -32,7 +32,7 @@ public class PullQueryBuilder {
         return query;
     }
 
-    public StringBuilder buildUpdateChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscirberUUID) {
+    public StringBuilder buildUpdateChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD) {
         StringBuilder query = new StringBuilder();
         String topLimit = "";
         if (SQLiteSyncConfig.PACKAGE_SIZE != null && !SQLiteSyncConfig.PACKAGE_SIZE.isEmpty())
@@ -56,14 +56,14 @@ public class PullQueryBuilder {
         return query;
     }
 
-    public StringBuilder buildDeleteChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscirberUUID) {
+    public StringBuilder buildDeleteChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscriberUUID) {
         StringBuilder query = new StringBuilder();
         query.append("select  ");
         query.append("m.rowid ");
         query.append("from " + tableSchema + ".mergecontent_" + tableName + " m ");
         if(filterVW_CD.trim().length() > 0 || filterVW.startsWith(tableSchema + ".fn_") || filterVW.startsWith("fn_")) {
             if(tableName.equalsIgnoreCase("mergeidentity"))
-                query.append("left join " + tableSchema + "." + filterVW + " vw on m.rowid=vw.rowid and vw.uniquename='" + subscirberUUID + "' and vw.subscriberid =" + subscriberId + " ");
+                query.append("left join " + tableSchema + "." + filterVW + " vw on m.rowid=vw.rowid and vw.uniquename='" + subscriberUUID + "' and vw.subscriberid =" + subscriberId + " ");
             else
                 query.append("left join " + tableSchema + "." + filterVW + " vw on m.rowid=vw.rowid " + filterVW_CD + " ");
             query.append("where vw.rowid is null  and m.subscriberid=" + subscriberId);

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullQueryBuilder.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullQueryBuilder.java
@@ -1,0 +1,78 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+import com.ampliapps.amplisync.SQLiteSyncConfig;
+
+public class PullQueryBuilder {
+    public StringBuilder buildInsertChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscirberUUID) {
+        StringBuilder query = new StringBuilder();
+        String topLimit = "";
+        if (SQLiteSyncConfig.PACKAGE_SIZE != null && !SQLiteSyncConfig.PACKAGE_SIZE.isEmpty())
+            topLimit = "LIMIT " + SQLiteSyncConfig.PACKAGE_SIZE;
+
+        query.append("select distinct ");
+        query.append("tb.*");
+        query.append("from " + tableSchema + "." + tableName + " tb ");
+        query.append("join (");
+        query.append("select vw.rowid ");
+        if(filterVW_CD.trim().length() > 0 || filterVW.startsWith("public.fn_") || filterVW.startsWith("fn_")) {
+            query.append("from " + tableSchema + "." + filterVW + " vw ");
+        } else {
+            query.append("from " + tableSchema + "." + tableName + " vw ");
+        }
+        query.append("where ");
+        query.append("not exists (select 1 from  " + tableSchema + ".MergeContent_" + tableName + " t where vw.rowid=t.rowid and t.SubscriberId=" + subscriberId + ") ");
+        if(!filterVW.startsWith(tableSchema + ".fn_") && !filterVW.startsWith("fn_"))
+            if(filterVW_CD.trim().length() > 0)
+                query.append("and vw.uniquename='"+subscirberUUID+"'");
+        query.append(" " + topLimit + "");
+        query.append(") inserts on tb.rowid = inserts.rowid ");
+        if(tableName.equalsIgnoreCase("mergeidentity"))
+            query.append("and tb.subscriberid =" + subscriberId);
+
+        return query;
+    }
+
+    public StringBuilder buildUpdateChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscirberUUID) {
+        StringBuilder query = new StringBuilder();
+        String topLimit = "";
+        if (SQLiteSyncConfig.PACKAGE_SIZE != null && !SQLiteSyncConfig.PACKAGE_SIZE.isEmpty())
+            topLimit = "limit " + SQLiteSyncConfig.PACKAGE_SIZE;
+
+        query.append("select distinct ");
+        query.append("tb.*");
+        query.append("from " + tableSchema + "." + tableName + " tb ");
+        if(filterVW_CD.trim().length() > 0 || filterVW.startsWith("public.fn_") || filterVW.startsWith("fn_")) {
+            query.append("join " + tableSchema + "." + filterVW + " vw on tb.rowid=vw.rowid ");
+            query.append("join " + tableSchema + ".mergecontent_" + tableName + " t on vw.rowid=t.rowid ");
+        } else {
+            query.append("join " + tableSchema + ".mergecontent_" + tableName + " t on tb.rowid=t.rowid ");
+        }
+
+        query.append("where t.record_has_changed=true and t.SubscriberId=" + subscriberId + " " + filterVW_CD + " ");
+        if(tableName.equalsIgnoreCase("mergeidentity"))
+            query.append(" and tb.subscriberid =" + subscriberId);
+        query.append(" " + topLimit + ";");
+
+        return query;
+    }
+
+    public StringBuilder buildDeleteChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscirberUUID) {
+        StringBuilder query = new StringBuilder();
+        query.append("select  ");
+        query.append("m.rowid ");
+        query.append("from " + tableSchema + ".mergecontent_" + tableName + " m ");
+        if(filterVW_CD.trim().length() > 0 || filterVW.startsWith(tableSchema + ".fn_") || filterVW.startsWith("fn_")) {
+            if(tableName.equalsIgnoreCase("mergeidentity"))
+                query.append("left join " + tableSchema + "." + filterVW + " vw on m.rowid=vw.rowid and vw.uniquename='" + subscirberUUID + "' and vw.subscriberid =" + subscriberId + " ");
+            else
+                query.append("left join " + tableSchema + "." + filterVW + " vw on m.rowid=vw.rowid " + filterVW_CD + " ");
+            query.append("where vw.rowid is null  and m.subscriberid=" + subscriberId);
+
+        } else {
+            query.append("left join " + tableSchema + "." + tableName + " vw on m.rowid=vw.rowid ");
+            query.append("where vw.rowid is null and m.subscriberid=" + subscriberId );
+        }
+
+        return query;
+    }
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLiteClientQueryBuilder.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLiteClientQueryBuilder.java
@@ -1,0 +1,55 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+public class SQLiteClientQueryBuilder {
+    public void buildQueries(DataObject tableSync, String tableSchema) {
+        String tableNameClear = tableSync.TableName;
+
+        DatabaseTable table = DatabaseTableGuavaCacheUtil.getTableUsingGuava(tableNameClear, tableSchema);
+
+        StringBuilder insertStatement = new StringBuilder();
+        StringBuilder updateStatment = new StringBuilder();
+
+        insertStatement.append("insert or replace into " + tableNameClear + " (");
+        for (DatabaseTableColumn col : table.Columns)
+            if (!col.Name.equalsIgnoreCase("mergeinsertsource")) {
+                insertStatement.append("[" + col.Name + "]");
+                insertStatement.append(",");
+            }
+
+        tableSync.QueryInsert = insertStatement.substring(0, insertStatement.toString().length() - 1) + ") values (";
+        insertStatement = new StringBuilder();
+        for (DatabaseTableColumn col : table.Columns)
+            if (!col.Name.equalsIgnoreCase("mergeinsertsource")) {
+                insertStatement.append("?");
+                insertStatement.append(",");
+            }
+        tableSync.QueryInsert += insertStatement.substring(0, insertStatement.toString().length() - 1) + ");";
+
+        updateStatment.append("update " + tableNameClear + " set ");
+        for (DatabaseTableColumn col : table.Columns)
+            if (!col.Name.equalsIgnoreCase("mergeinsertsource")) {
+                if (!col.IsInPrimaryKey) {
+                    updateStatment.append("[" + col.Name + "]");
+                    updateStatment.append("=?,");
+                }
+            }
+
+        updateStatment = new StringBuilder(updateStatment.substring(0, updateStatment.toString().length() - 1));
+
+        updateStatment.append(" where ");
+
+        if (table.PrimaryKeyColumns.size() > 0) {
+            for (String pk : table.PrimaryKeyColumns) {
+                updateStatment.append(pk);
+                updateStatment.append("=? and ");
+            }
+
+            tableSync.QueryUpdate = updateStatment.substring(0, updateStatment.toString().length() - 5) + ";";
+        } else {
+            updateStatment.append(SQLQueries.GET_ROWID_COLUMN_NAME() + "=?");
+            tableSync.QueryUpdate = updateStatment + ";";
+        }
+
+        tableSync.QueryDelete = "delete from " + tableNameClear + " where " + SQLQueries.GET_ROWID_COLUMN_NAME() + "=";
+    }
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncRecordMapper.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncRecordMapper.java
@@ -1,0 +1,43 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+import com.ampliapps.amplisync.Logs;
+import com.ampliapps.amplisync.SQLiteSyncConfig;
+import com.ampliapps.amplisync.SyncServer.Helpers;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Base64;
+import java.util.Date;
+
+public class SyncRecordMapper {
+
+    public void writeColumn(ObjectNode record, String columnName, String colDataType, String colValue, Boolean wasNull) {
+        record.put(columnName, 1);
+        if (colDataType.equalsIgnoreCase("Boolean") || colDataType.equalsIgnoreCase("bool") || colDataType.equalsIgnoreCase("bit")) {
+            if (colValue == null || colValue.isEmpty() || colValue.equalsIgnoreCase("False"))
+                record.put(columnName, 0);
+            else
+                record.put(columnName, 1);
+        } else if (Helpers.TypeConvertionTableIsBLOBType(colDataType)) {
+            if (!wasNull) {
+                byte[] bytesEncoded = Base64.getEncoder().encodeToString(colValue.getBytes()).getBytes();
+                record.put(columnName, new String(bytesEncoded));
+            }
+        } else if (colDataType.equalsIgnoreCase("datetime") || colDataType.equalsIgnoreCase("date")) {
+            DateFormat format = new SimpleDateFormat(SQLiteSyncConfig.DATE_FORMAT);
+            if (colValue != null && !colValue.isEmpty()) {
+                try {
+                    if(colValue.trim().length() == 10)
+                        colValue += " 00:00:00";
+                    Date date = format.parse(colValue);
+                    record.put(columnName, format.format(date));
+                } catch (ParseException e) {
+                    Logs.write(Logs.Level.ERROR, "BuildRecord() " + e.getMessage());
+                }
+            }
+        } else
+            record.put(columnName, colValue);
+    }
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -38,6 +38,7 @@ public class SyncService {
     List<DataObject> dataToSync = new ArrayList<>();
     private final SQLQueries QUERIES = new SQLQueries();
     private final SyncRecordMapper recordMapper = new SyncRecordMapper();
+    private final PullQueryBuilder pullQueryBuilder = new PullQueryBuilder();
     public CachedRowSet tablesData = null;
     public CachedRowSet tablesDataUpdates = null;
     public CachedRowSet tablesDataDeletes = null;
@@ -164,9 +165,9 @@ public class SyncService {
             Logs.write(Logs.Level.TRACE, "Using filter [" + tableFilter + "] for table " + tableName);
         }
 
-        StringBuilder queryInserts = BuildMergeQueryInserts(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
-        StringBuilder queryUpdates = BuildMergeQueryUpdates(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
-        StringBuilder queryDeletes = BuildMergeQueryDeletes(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
+        StringBuilder queryInserts = pullQueryBuilder.buildInsertChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
+        StringBuilder queryUpdates = pullQueryBuilder.buildUpdateChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
+        StringBuilder queryDeletes = pullQueryBuilder.buildDeleteChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
 
         SchemaGenerator schemaGenerator = new SchemaGenerator();
         Connection cn = Database.getInstance().GetDBConnection();
@@ -315,80 +316,6 @@ public class SyncService {
         tableSync.Records = root;
         if (hasRows)
             dataToSync.add(tableSync);
-    }
-
-
-    public StringBuilder BuildMergeQueryInserts(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscirberUUID) {
-        StringBuilder query = new StringBuilder();
-        String topLimit = "";
-        if (SQLiteSyncConfig.PACKAGE_SIZE != null && !SQLiteSyncConfig.PACKAGE_SIZE.isEmpty())
-            topLimit = "LIMIT " + SQLiteSyncConfig.PACKAGE_SIZE;
-
-        query.append("select distinct ");
-        query.append("tb.*");
-        query.append("from " + tableSchema + "." + tableName + " tb ");
-        query.append("join (");
-        query.append("select vw.rowid ");
-        if(filterVW_CD.trim().length() > 0 || filterVW.startsWith("public.fn_") || filterVW.startsWith("fn_")) {
-            query.append("from " + tableSchema + "." + filterVW + " vw ");
-        } else {
-            query.append("from " + tableSchema + "." + tableName + " vw ");
-        }
-        query.append("where ");
-        query.append("not exists (select 1 from  " + tableSchema + ".MergeContent_" + tableName + " t where vw.rowid=t.rowid and t.SubscriberId=" + subscriberId + ") ");
-        if(!filterVW.startsWith(tableSchema + ".fn_") && !filterVW.startsWith("fn_"))
-            if(filterVW_CD.trim().length() > 0)
-                query.append("and vw.uniquename='"+subscirberUUID+"'");
-        query.append(" " + topLimit + "");
-        query.append(") inserts on tb.rowid = inserts.rowid ");
-        if(tableName.equalsIgnoreCase("mergeidentity"))
-            query.append("and tb.subscriberid =" + subscriberId);
-
-        return query;
-    }
-
-    public StringBuilder BuildMergeQueryUpdates(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscirberUUID) {
-        StringBuilder query = new StringBuilder();
-        String topLimit = "";
-        if (SQLiteSyncConfig.PACKAGE_SIZE != null && !SQLiteSyncConfig.PACKAGE_SIZE.isEmpty())
-            topLimit = "limit " + SQLiteSyncConfig.PACKAGE_SIZE;
-
-        query.append("select distinct ");
-        query.append("tb.*");
-        query.append("from " + tableSchema + "." + tableName + " tb ");
-        if(filterVW_CD.trim().length() > 0 || filterVW.startsWith("public.fn_") || filterVW.startsWith("fn_")) {
-            query.append("join " + tableSchema + "." + filterVW + " vw on tb.rowid=vw.rowid ");
-            query.append("join " + tableSchema + ".mergecontent_" + tableName + " t on vw.rowid=t.rowid ");
-        } else {
-            query.append("join " + tableSchema + ".mergecontent_" + tableName + " t on tb.rowid=t.rowid ");
-        }
-
-        query.append("where t.record_has_changed=true and t.SubscriberId=" + subscriberId + " " + filterVW_CD + " ");
-        if(tableName.equalsIgnoreCase("mergeidentity"))
-            query.append(" and tb.subscriberid =" + subscriberId);
-        query.append(" " + topLimit + ";");
-
-        return query;
-    }
-
-    public StringBuilder BuildMergeQueryDeletes(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscirberUUID) {
-        StringBuilder query = new StringBuilder();
-        query.append("select  ");
-        query.append("m.rowid ");
-        query.append("from " + tableSchema + ".mergecontent_" + tableName + " m ");
-        if(filterVW_CD.trim().length() > 0 || filterVW.startsWith(tableSchema + ".fn_") || filterVW.startsWith("fn_")) {
-            if(tableName.equalsIgnoreCase("mergeidentity"))
-                query.append("left join " + tableSchema + "." + filterVW + " vw on m.rowid=vw.rowid and vw.uniquename='" + subscirberUUID + "' and vw.subscriberid =" + subscriberId + " ");
-            else
-                query.append("left join " + tableSchema + "." + filterVW + " vw on m.rowid=vw.rowid " + filterVW_CD + " ");
-            query.append("where vw.rowid is null  and m.subscriberid=" + subscriberId);
-
-        } else {
-            query.append("left join " + tableSchema + "." + tableName + " vw on m.rowid=vw.rowid ");
-            query.append("where vw.rowid is null and m.subscriberid=" + subscriberId );
-        }
-
-        return query;
     }
 
     private void GenerateQueries(DataObject tableSync, String tableSchema) {

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -40,6 +40,7 @@ public class SyncService {
     private final SyncRecordMapper recordMapper = new SyncRecordMapper();
     private final PullQueryBuilder pullQueryBuilder = new PullQueryBuilder();
     private final SyncSessionStore syncSessionStore = new SyncSessionStore();
+    private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
     public CachedRowSet tablesData = null;
     public CachedRowSet tablesDataUpdates = null;
     public CachedRowSet tablesDataDeletes = null;
@@ -90,7 +91,7 @@ public class SyncService {
                 DataObject emptySync = new DataObject();
                 emptySync.SyncId = -1;
                 dataToSync.add(emptySync);
-                SetSyncFinishMarker(syncId.toString(), tableSchema);
+                syncSessionRepository.finishSync(syncId.toString(), tableSchema);
             }
 
         } catch (SQLException e) {
@@ -130,7 +131,7 @@ public class SyncService {
             }
         }
 
-        Integer syncId = SetSyncStartMarker(subscriberId, tableId, schema);
+        Integer syncId = syncSessionRepository.startSync(subscriberId, tableId, schema);
 
         syncSessionStore.writeSyncData(syncId.toString(), tablesData, tablesDataUpdates, tablesDataDeletes);
 
@@ -391,57 +392,8 @@ public class SyncService {
         }
 
         UpdateSyncData(Integer.parseInt(syncId), schema, tableName, subscriberId, cachedDataInserts, cachedDataUpdates, cachedDataDeletes);
-        SetSyncFinishMarker(syncId, schema);
+        syncSessionRepository.finishSync(syncId, schema);
     }
-
-    private void SetSyncFinishMarker(String syncId, String schema) {
-        Connection cn = Database.getInstance().GetDBConnection();
-        try {
-            PreparedStatement query = cn.prepareStatement(QUERIES.COMMIT_SYNC_UPDATE(schema));
-            query.setInt(1, Integer.parseInt(syncId));
-            query.execute();
-        } catch (SQLException e) {
-            Logs.write(Logs.Level.ERROR, "SetSyncFinishMarker() " + e.getMessage());
-        } finally {
-            JDBCCloser.close(cn);
-        }
-    }
-
-    private Integer SetSyncStartMarker(String subscriberId, Integer tableId, String schema) {
-        Connection cn = Database.getInstance().GetDBConnection();
-        try {
-            Integer id = 0;
-            Integer affectedRows = 0;
-
-            PreparedStatement query = cn.prepareStatement(QUERIES.START_NEW_SYNC(schema), Statement.RETURN_GENERATED_KEYS);
-            query.setInt(1, Integer.parseInt(subscriberId));
-            query.setString(2, "");
-            query.setInt(3, tableId);
-
-
-            affectedRows = query.executeUpdate();
-
-            if (affectedRows == 0) {
-                Logs.write(Logs.Level.ERROR, "Creating new sync failed, no ID obtained.");
-            }
-
-            try (ResultSet generatedKeys = query.getGeneratedKeys()) {
-                if (generatedKeys.next()) {
-                    id = generatedKeys.getInt(1);
-                } else {
-                    Logs.write(Logs.Level.ERROR, "Creating new sync failed, no ID obtained.");
-                }
-            }
-
-            return id;
-        } catch (SQLException e) {
-            Logs.write(Logs.Level.ERROR, "SetSyncStartMarker() " + e.getMessage());
-        } finally {
-            JDBCCloser.close(cn);
-        }
-        return 0;
-    }
-
     private void UpdateSyncData(Integer syncId, String schema, String tableName, Integer subscriberId, CachedRowSet cachedDataInserts, CachedRowSet cachedDataUpdates, CachedRowSet cachedDataDeletes) {
 
         if (cachedDataInserts != null) {
@@ -520,12 +472,12 @@ public class SyncService {
         Integer syncId = StartNewReception(subscriberId, receivedData, schema);
 
         CommitChangesToDb(receivedData, schema, subscriberId);
-        SetSyncFinishMarker(syncId.toString(), schema);
+        syncSessionRepository.finishSync(syncId.toString(), schema);
         Logs.write(Logs.Level.INFO, "Finished receiving data from subscriber " + subscriberUUID);
     }
 
     private Integer StartNewReception(String subscriberId, ObjectNode data, String schema) {
-        Integer syncId = SetSyncStartMarker(subscriberId, -1, schema);
+        Integer syncId = syncSessionRepository.startSync(subscriberId, -1, schema);
         BufferedWriter writer = null;
 
         File theDir = new File(SQLiteSyncConfig.WORKING_DIR + "ReceivedData");

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -39,6 +39,7 @@ public class SyncService {
     private final SQLQueries QUERIES = new SQLQueries();
     private final SyncRecordMapper recordMapper = new SyncRecordMapper();
     private final PullQueryBuilder pullQueryBuilder = new PullQueryBuilder();
+    private final SyncSessionStore syncSessionStore = new SyncSessionStore();
     public CachedRowSet tablesData = null;
     public CachedRowSet tablesDataUpdates = null;
     public CachedRowSet tablesDataDeletes = null;
@@ -131,10 +132,7 @@ public class SyncService {
 
         Integer syncId = SetSyncStartMarker(subscriberId, tableId, schema);
 
-        BinaryWriter binaryWriter = new BinaryWriter();
-        binaryWriter.writeToBinary(SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + ".dat", tablesData);
-        binaryWriter.writeToBinary(SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + "_updates.dat", tablesDataUpdates);
-        binaryWriter.writeToBinary(SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + "_deletes.dat", tablesDataDeletes);
+        syncSessionStore.writeSyncData(syncId, tablesData, tablesDataUpdates, tablesDataDeletes);
 
         return syncId;
     }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -41,6 +41,7 @@ public class SyncService {
     private final PullQueryBuilder pullQueryBuilder = new PullQueryBuilder();
     private final SyncSessionStore syncSessionStore = new SyncSessionStore();
     private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
+    private final SQLiteClientQueryBuilder sqLiteClientQueryBuilder = new SQLiteClientQueryBuilder();
     public CachedRowSet tablesData = null;
     public CachedRowSet tablesDataUpdates = null;
     public CachedRowSet tablesDataDeletes = null;
@@ -143,7 +144,7 @@ public class SyncService {
         boolean hasRows = false;
         tableSync.TableName = tableName;
         tableSync.MaxPackageSize = SQLiteSyncConfig.PACKAGE_SIZE;
-        GenerateQueries(tableSync, tableSchema);
+        sqLiteClientQueryBuilder.buildQueries(tableSync, tableSchema);
         String filterVW = tableSchema + "." + tableName;
 
         if (tableSchema == null || tableSchema.isEmpty())
@@ -315,58 +316,6 @@ public class SyncService {
         tableSync.Records = root;
         if (hasRows)
             dataToSync.add(tableSync);
-    }
-
-    private void GenerateQueries(DataObject tableSync, String tableSchema) {
-        String tableNameClear = tableSync.TableName;
-
-        DatabaseTable table = DatabaseTableGuavaCacheUtil.getTableUsingGuava(tableNameClear, tableSchema);
-
-        StringBuilder insertStatement = new StringBuilder();
-        StringBuilder updateStatment = new StringBuilder();
-
-        insertStatement.append("insert or replace into " + tableNameClear + " (");
-        for (DatabaseTableColumn col : table.Columns)
-            if (!col.Name.equalsIgnoreCase("mergeinsertsource")) {
-                insertStatement.append("[" + col.Name + "]");
-                insertStatement.append(",");
-            }
-
-        tableSync.QueryInsert = insertStatement.substring(0, insertStatement.toString().length() - 1) + ") values (";
-        insertStatement = new StringBuilder();
-        for (DatabaseTableColumn col : table.Columns)
-            if (!col.Name.equalsIgnoreCase("mergeinsertsource")) {
-                insertStatement.append("?");
-                insertStatement.append(",");
-            }
-        tableSync.QueryInsert += insertStatement.substring(0, insertStatement.toString().length() - 1) + ");";
-
-        updateStatment.append("update " + tableNameClear + " set ");
-        for (DatabaseTableColumn col : table.Columns)
-            if (!col.Name.equalsIgnoreCase("mergeinsertsource")) {
-                if (!col.IsInPrimaryKey) {
-                    updateStatment.append("[" + col.Name + "]");
-                    updateStatment.append("=?,");
-                }
-            }
-
-        updateStatment = new StringBuilder(updateStatment.substring(0, updateStatment.toString().length() - 1));
-
-        updateStatment.append(" where ");
-
-        if (table.PrimaryKeyColumns.size() > 0) {
-            for (String pk : table.PrimaryKeyColumns) {
-                updateStatment.append(pk);
-                updateStatment.append("=? and ");
-            }
-
-            tableSync.QueryUpdate = updateStatment.substring(0, updateStatment.toString().length() - 5) + ";";
-        } else {
-            updateStatment.append(SQLQueries.GET_ROWID_COLUMN_NAME() + "=?");
-            tableSync.QueryUpdate = updateStatment + ";";
-        }
-
-        tableSync.QueryDelete = "delete from " + tableNameClear + " where " + SQLQueries.GET_ROWID_COLUMN_NAME() + "=";
     }
 
     public void CommitSync(String syncId, String schema) {

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -166,7 +166,7 @@ public class SyncService {
         }
 
         StringBuilder queryInserts = pullQueryBuilder.buildInsertChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
-        StringBuilder queryUpdates = pullQueryBuilder.buildUpdateChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
+        StringBuilder queryUpdates = pullQueryBuilder.buildUpdateChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD);
         StringBuilder queryDeletes = pullQueryBuilder.buildDeleteChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
 
         SchemaGenerator schemaGenerator = new SchemaGenerator();

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -132,7 +132,7 @@ public class SyncService {
 
         Integer syncId = SetSyncStartMarker(subscriberId, tableId, schema);
 
-        syncSessionStore.writeSyncData(syncId, tablesData, tablesDataUpdates, tablesDataDeletes);
+        syncSessionStore.writeSyncData(syncId.toString(), tablesData, tablesDataUpdates, tablesDataDeletes);
 
         return syncId;
     }
@@ -369,10 +369,9 @@ public class SyncService {
     }
 
     public void CommitSync(String syncId, String schema) {
-        BinaryWriter binaryWriter = new BinaryWriter();
-        CachedRowSet cachedDataInserts = (CachedRowSet) binaryWriter.readFromBinaryFile(SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + ".dat");
-        CachedRowSet cachedDataUpdates = (CachedRowSet) binaryWriter.readFromBinaryFile(SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + "_updates.dat");
-        CachedRowSet cachedDataDeletes = (CachedRowSet) binaryWriter.readFromBinaryFile(SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + "_deletes.dat");
+        CachedRowSet cachedDataInserts = syncSessionStore.readInserts(syncId);
+        CachedRowSet cachedDataUpdates = syncSessionStore.readUpdates(syncId);
+        CachedRowSet cachedDataDeletes = syncSessionStore.readDeletes(syncId);
 
         String tableName = "";
         int subscriberId = 0;

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -37,6 +37,7 @@ public class SyncService {
     public Integer syncIdForTestPurpose = -1;
     List<DataObject> dataToSync = new ArrayList<>();
     private final SQLQueries QUERIES = new SQLQueries();
+    private final SyncRecordMapper recordMapper = new SyncRecordMapper();
     public CachedRowSet tablesData = null;
     public CachedRowSet tablesDataUpdates = null;
     public CachedRowSet tablesDataDeletes = null;
@@ -204,7 +205,7 @@ public class SyncService {
                                 String colDataType = rsmd.getColumnTypeName(i);
                                 String colValue = tablesData.getString(i);
                                 Boolean wasNull = tablesData.wasNull();
-                                BuildRecord(record, columnName, colDataType, colValue, wasNull);
+                                recordMapper.writeColumn(record, columnName, colDataType, colValue, wasNull);
                             }
                             inserts.add(record);
                             addedRecords++;
@@ -252,7 +253,7 @@ public class SyncService {
                                     String colDataType = rsmd.getColumnTypeName(i);
                                     String colValue = tablesDataUpdates.getString(i);
                                     Boolean wasNull = tablesDataUpdates.wasNull();
-                                    BuildRecord(record, columnName, colDataType, colValue, wasNull);
+                                    recordMapper.writeColumn(record, columnName, colDataType, colValue, wasNull);
                                 }
                                 updates.add(record);
                                 addedRecords++;
@@ -316,33 +317,6 @@ public class SyncService {
             dataToSync.add(tableSync);
     }
 
-    private void BuildRecord(ObjectNode record, String columnName, String colDataType, String colValue, Boolean wasNull) {
-        record.put(columnName, 1);
-        if (colDataType.equalsIgnoreCase("Boolean") || colDataType.equalsIgnoreCase("bool") || colDataType.equalsIgnoreCase("bit")) {
-            if (colValue == null || colValue.isEmpty() || colValue.equalsIgnoreCase("False"))
-                record.put(columnName, 0);
-            else
-                record.put(columnName, 1);
-        } else if (Helpers.TypeConvertionTableIsBLOBType(colDataType)) {
-            if (!wasNull) {
-                byte[] bytesEncoded = Base64.getEncoder().encodeToString(colValue.getBytes()).getBytes();
-                record.put(columnName, new String(bytesEncoded));
-            }
-        } else if (colDataType.equalsIgnoreCase("datetime") || colDataType.equalsIgnoreCase("date")) {
-            DateFormat format = new SimpleDateFormat(SQLiteSyncConfig.DATE_FORMAT);
-            if (colValue != null && !colValue.isEmpty()) {
-                try {
-                    if(colValue.trim().length() == 10)
-                        colValue += " 00:00:00";
-                    Date date = format.parse(colValue);
-                    record.put(columnName, format.format(date));
-                } catch (ParseException e) {
-                    Logs.write(Logs.Level.ERROR, "BuildRecord() " + e.getMessage());
-                }
-            }
-        } else
-            record.put(columnName, colValue);
-    }
 
     public StringBuilder BuildMergeQueryInserts(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscirberUUID) {
         StringBuilder query = new StringBuilder();

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionRepository.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionRepository.java
@@ -1,0 +1,61 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+import com.ampliapps.amplisync.JDBCCloser;
+import com.ampliapps.amplisync.Logs;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class SyncSessionRepository {
+    private final SQLQueries QUERIES = new SQLQueries();
+
+    public Integer startSync(String subscriberId, Integer tableId, String schema) {
+        Connection cn = Database.getInstance().GetDBConnection();
+        try {
+            Integer id = 0;
+            Integer affectedRows = 0;
+
+            PreparedStatement query = cn.prepareStatement(QUERIES.START_NEW_SYNC(schema), Statement.RETURN_GENERATED_KEYS);
+            query.setInt(1, Integer.parseInt(subscriberId));
+            query.setString(2, "");
+            query.setInt(3, tableId);
+
+            affectedRows = query.executeUpdate();
+
+            if (affectedRows == 0) {
+                Logs.write(Logs.Level.ERROR, "Creating new sync failed, no ID obtained.");
+            }
+
+            try (ResultSet generatedKeys = query.getGeneratedKeys()) {
+                if (generatedKeys.next()) {
+                    id = generatedKeys.getInt(1);
+                } else {
+                    Logs.write(Logs.Level.ERROR, "Creating new sync failed, no ID obtained.");
+                }
+            }
+
+            return id;
+        } catch (SQLException e) {
+            Logs.write(Logs.Level.ERROR, "SetSyncStartMarker() " + e.getMessage());
+        } finally {
+            JDBCCloser.close(cn);
+        }
+        return 0;
+    }
+
+    public void finishSync(String syncId, String schema) {
+        Connection cn = Database.getInstance().GetDBConnection();
+        try {
+            PreparedStatement query = cn.prepareStatement(QUERIES.COMMIT_SYNC_UPDATE(schema));
+            query.setInt(1, Integer.parseInt(syncId));
+            query.execute();
+        } catch (SQLException e) {
+            Logs.write(Logs.Level.ERROR, "SetSyncFinishMarker() " + e.getMessage());
+        } finally {
+            JDBCCloser.close(cn);
+        }
+    }
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
@@ -5,22 +5,39 @@ import com.ampliapps.amplisync.SQLiteSyncConfig;
 import javax.sql.rowset.CachedRowSet;
 
 public class SyncSessionStore {
-    public void writeSyncData(Integer syncId, CachedRowSet inserts, CachedRowSet updates, CachedRowSet deletes) {
-        BinaryWriter binaryWriter = new BinaryWriter();
+
+    public void writeSyncData(String syncId, CachedRowSet inserts, CachedRowSet updates, CachedRowSet deletes) {
+        BinaryWriter binaryWriter = binaryWriter();
         binaryWriter.writeToBinary(syncDataFile(syncId), inserts);
         binaryWriter.writeToBinary(syncDataUpdatesFile(syncId), updates);
         binaryWriter.writeToBinary(syncDataDeletesFile(syncId), deletes);
     }
 
-    private String syncDataFile(Integer syncId) {
+    public CachedRowSet readInserts(String syncId) {
+        return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataFile(syncId));
+    }
+
+    public CachedRowSet readUpdates(String syncId) {
+        return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataUpdatesFile(syncId));
+    }
+
+    public CachedRowSet readDeletes(String syncId) {
+        return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataDeletesFile(syncId));
+    }
+
+    private BinaryWriter binaryWriter() {
+        return new BinaryWriter();
+    }
+
+    private String syncDataFile(String syncId) {
         return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + ".dat";
     }
 
-    private String syncDataUpdatesFile(Integer syncId) {
+    private String syncDataUpdatesFile(String syncId) {
         return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + "_updates.dat";
     }
 
-    private String syncDataDeletesFile(Integer syncId) {
+    private String syncDataDeletesFile(String syncId) {
         return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + "_deletes.dat";
     }
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
@@ -1,0 +1,26 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+import com.ampliapps.amplisync.SQLiteSyncConfig;
+
+import javax.sql.rowset.CachedRowSet;
+
+public class SyncSessionStore {
+    public void writeSyncData(Integer syncId, CachedRowSet inserts, CachedRowSet updates, CachedRowSet deletes) {
+        BinaryWriter binaryWriter = new BinaryWriter();
+        binaryWriter.writeToBinary(syncDataFile(syncId), inserts);
+        binaryWriter.writeToBinary(syncDataUpdatesFile(syncId), updates);
+        binaryWriter.writeToBinary(syncDataDeletesFile(syncId), deletes);
+    }
+
+    private String syncDataFile(Integer syncId) {
+        return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + ".dat";
+    }
+
+    private String syncDataUpdatesFile(Integer syncId) {
+        return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + "_updates.dat";
+    }
+
+    private String syncDataDeletesFile(Integer syncId) {
+        return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + "_deletes.dat";
+    }
+}


### PR DESCRIPTION
## Summary

Refactors the `sync-compressed` backend flow by extracting methods from `SyncService`.

The goal is to make the pull sync flow easier to understand and safer to
continue refactoring, without changing the existing synchronization behavior.

## Review Guide

This PR is split into small commits and is best reviewed commit by commit.

### 1. [`e31cd22`](https://github.com/AMPLIFIER-sp-z-o-o/ampli-sync/commit/e31cd22803bfea132207a5423511e0dd90c0b975) `refactor: extract sync record mapper`

Extracts mapping of a single SQL result column into a JSON record from `SyncService` into `SyncRecordMapper`.

 ### 2. [`614f818`](https://github.com/AMPLIFIER-sp-z-o-o/ampli-sync/commit/614f818c8ba42eb1e5bd2fe6900ccbe0476b4ac8)`refactor: extract pull query builder`

  Extracts PostgreSQL pull query generation  from `SyncService` into `PullQueryBuilder`.


  ### 3/ [`025b29f`](https://github.com/AMPLIFIER-sp-z-o-o/ampli-sync/commit/025b29fc511db7713ce6157e6d59d55e8ea71d60)`refactor: clean up pull query builder parameters`

Removes an unused parameter from the pull update query builder and fixes the
`subscriberUUID` parameter naming.


### 4. [`0e49fe3`](https://github.com/AMPLIFIER-sp-z-o-o/ampli-sync/commit/0e49fe3be0253cd18623b1819a7da8977a215cbb) `refactor: extract sync session store writes`

Extracts writing sync session `.dat` files into `SyncSessionStore`.


### 5. [`5b4e87e`](https://github.com/AMPLIFIER-sp-z-o-o/ampli-sync/commit/5b4e87eb32bf3755498edaeaa62b752bd52186bc) `refactor: read commit-sync session data through store`

Moves reading sync session `.dat` files in `commit-sync` into
`SyncSessionStore`.


### 6. [`d9d44ab`](https://github.com/AMPLIFIER-sp-z-o-o/ampli-sync/commit/d9d44ab5a07d134b8dde494c9e1246004f1186d5)`refactor: extract sync session repository`

Extracts `mergesync` start/finish database operations from `SyncService` into
`SyncSessionRepository`.


### 7. [`582db5f`](https://github.com/AMPLIFIER-sp-z-o-o/ampli-sync/commit/582db5f6f0a80b1de5094142c7aa9f07c9588a51)`refactor: extract sqlite client query builder`

Extracts SQLite client query construction from `SyncService` into
`SQLiteClientQueryBuilder`.

## Verification

  - `mvn test` in `tools/dev-client` (regression tests via dev-client)

## Notes

The extracted classes only isolate specific responsibilities:
- SQL result column mapping,
- PostgreSQL pull query construction,
- sync session file storage,
- `mergesync` database operations,
- SQLite client query construction.
## Next PR

next PR will continue with the `sync-compressed` flow by extracting the pull change enumeration method.

