### PR TITLE
refactor: extract pull change mapping

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
@@ -1,0 +1,161 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+import com.ampliapps.amplisync.JDBCCloser;
+import com.ampliapps.amplisync.Logs;
+import com.ampliapps.amplisync.SQLiteSyncConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import javax.sql.rowset.RowSetProvider;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class PullChangeEnumerator {
+    private final SyncRecordMapper recordMapper = new SyncRecordMapper();
+
+    public PullChangeSet enumerate(StringBuilder queryInserts, StringBuilder queryUpdates, StringBuilder queryDeletes) {
+        PullChangeSet changeSet = new PullChangeSet();
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode root = mapper.createObjectNode();
+
+        int addedRecords = 0;
+
+        Connection cn = Database.getInstance().GetDBConnection();
+        try {
+            Statement cmd = cn.createStatement();
+            Logs.write(Logs.Level.TRACE, queryInserts.toString());
+            boolean hasResults = cmd.execute(queryInserts.toString());
+            do {
+                if (hasResults) {
+                    try (ResultSet rs = cmd.getResultSet()) {
+                        changeSet.Inserts = RowSetProvider.newFactory().createCachedRowSet();
+                        changeSet.Inserts.populate(rs);
+                        changeSet.Inserts.beforeFirst();
+
+                        ArrayNode inserts = mapper.createArrayNode();
+                        while (changeSet.Inserts.next()) {
+                            changeSet.HasRows = true;
+                            ObjectNode record = mapper.createObjectNode();
+                            ResultSetMetaData rsmd = changeSet.Inserts.getMetaData();
+
+                            for (int i = 1; i <= rsmd.getColumnCount(); i++) {
+                                String columnName = rsmd.getColumnName(i);
+                                String colDataType = rsmd.getColumnTypeName(i);
+                                String colValue = changeSet.Inserts.getString(i);
+                                Boolean wasNull = changeSet.Inserts.wasNull();
+
+                                recordMapper.writeColumn(record, columnName, colDataType, colValue, wasNull);
+                            }
+
+                            inserts.add(record);
+                            addedRecords++;
+
+                            if (addedRecords == Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE))
+                                break;
+                        }
+
+                        root.set("inserts", inserts);
+                    } catch (Exception e) {
+                        Logs.write(Logs.Level.ERROR, "EnumerateChanges() " + e.getMessage());
+                    }
+                }
+
+                hasResults = cmd.getMoreResults();
+            } while (hasResults || cmd.getUpdateCount() != -1);
+        } catch (SQLException e) {
+            Logs.write(Logs.Level.ERROR, "EnumerateChanges() " + e.getMessage());
+        } finally {
+            JDBCCloser.close(cn);
+        }
+
+        if (addedRecords != Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE)) {
+            cn = Database.getInstance().GetDBConnection();
+            try {
+                Statement cmd = cn.createStatement();
+                Logs.write(Logs.Level.TRACE, queryUpdates.toString());
+                boolean hasResults = cmd.execute(queryUpdates.toString());
+                do {
+                    if (hasResults) {
+                        try (ResultSet rs = cmd.getResultSet()) {
+                            changeSet.Updates = RowSetProvider.newFactory().createCachedRowSet();
+                            changeSet.Updates.populate(rs);
+                            changeSet.Updates.beforeFirst();
+
+                            ArrayNode updates = mapper.createArrayNode();
+                            while (changeSet.Updates.next()) {
+                                ObjectNode record = mapper.createObjectNode();
+                                ResultSetMetaData rsmd = changeSet.Updates.getMetaData();
+                                changeSet.HasRows = true;
+
+                                for (int i = 1; i <= rsmd.getColumnCount(); i++) {
+                                    String columnName = rsmd.getColumnName(i);
+                                    String colDataType = rsmd.getColumnTypeName(i);
+                                    String colValue = changeSet.Updates.getString(i);
+                                    Boolean wasNull = changeSet.Updates.wasNull();
+
+                                    recordMapper.writeColumn(record, columnName, colDataType, colValue, wasNull);
+                                }
+
+                                updates.add(record);
+                                addedRecords++;
+                            }
+
+                            root.set("updates", updates);
+                        } catch (Exception e) {
+                            Logs.write(Logs.Level.ERROR, "EnumarateChanges() updates " + e.getMessage());
+                        }
+                    }
+
+                    hasResults = cmd.getMoreResults();
+                } while (hasResults || cmd.getUpdateCount() != -1);
+            } catch (SQLException e) {
+                Logs.write(Logs.Level.ERROR, "EnumarateChanges() updates " + e.getMessage());
+            } finally {
+                JDBCCloser.close(cn);
+            }
+        }
+
+        if (addedRecords != Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE)) {
+            cn = Database.getInstance().GetDBConnection();
+            try {
+                Statement cmd = cn.createStatement();
+                Logs.write(Logs.Level.TRACE, queryDeletes.toString());
+                boolean hasResults = cmd.execute(queryDeletes.toString());
+                do {
+                    if (hasResults) {
+                        try (ResultSet rs = cmd.getResultSet()) {
+                            changeSet.Deletes = RowSetProvider.newFactory().createCachedRowSet();
+                            changeSet.Deletes.populate(rs);
+                            changeSet.Deletes.beforeFirst();
+
+                            ArrayNode deletes = mapper.createArrayNode();
+                            while (changeSet.Deletes.next()) {
+                                changeSet.HasRows = true;
+                                deletes.add(mapper.createObjectNode().put("rowid", changeSet.Deletes.getString(1)));
+                                addedRecords++;
+                            }
+
+                            root.set("deletes", deletes);
+                        } catch (Exception e) {
+                            Logs.write(Logs.Level.ERROR, "EnumarateChanges() deletes " + e.getMessage());
+                        }
+                    }
+
+                    hasResults = cmd.getMoreResults();
+                } while (hasResults || cmd.getUpdateCount() != -1);
+            } catch (SQLException e) {
+                Logs.write(Logs.Level.ERROR, "EnumarateChanges() deletes " + e.getMessage());
+            } finally {
+                JDBCCloser.close(cn);
+            }
+        }
+
+        changeSet.RowsCount = addedRecords;
+        changeSet.Records = root;
+        return changeSet;
+    }
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeSet.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeSet.java
@@ -1,0 +1,14 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import javax.sql.rowset.CachedRowSet;
+
+public class PullChangeSet {
+    public ObjectNode Records;
+    public Integer RowsCount = 0;
+    public Boolean HasRows = false;
+    public CachedRowSet Inserts;
+    public CachedRowSet Updates;
+    public CachedRowSet Deletes;
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -40,6 +40,7 @@ public class SyncService {
     private final SyncSessionStore syncSessionStore = new SyncSessionStore();
     private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
     private final SQLiteClientQueryBuilder sqLiteClientQueryBuilder = new SQLiteClientQueryBuilder();
+    private final PullChangeEnumerator pullChangeEnumerator = new PullChangeEnumerator();
     public CachedRowSet tablesData = null;
     public CachedRowSet tablesDataUpdates = null;
     public CachedRowSet tablesDataDeletes = null;
@@ -168,7 +169,7 @@ public class SyncService {
         StringBuilder queryDeletes = pullQueryBuilder.buildDeleteChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
 
         SchemaGenerator schemaGenerator = new SchemaGenerator();
-        Connection cn = Database.getInstance().GetDBConnection();
+
         DatabaseTable table = DatabaseTableGuavaCacheUtil.getTableUsingGuava(tableName, tableSchema);
         if (!tableName.equalsIgnoreCase("mergeidentity")) {
             tableSync.TriggerInsert =  "select 1;";
@@ -179,141 +180,18 @@ public class SyncService {
             tableSync.TriggerDeleteDrop = "drop trigger if exists \"trmergedelete_" + tableName + "\"";
         }
 
-        ObjectMapper mapper = new ObjectMapper();
-        ObjectNode root = mapper.createObjectNode();
+        PullChangeSet changeSet = pullChangeEnumerator.enumerate(queryInserts, queryUpdates, queryDeletes);
 
+        tablesData = changeSet.Inserts;
+        tablesDataUpdates = changeSet.Updates;
+        tablesDataDeletes = changeSet.Deletes;
 
-        int addedRecords = 0; //this is equivalent of limit on db
-        try {
-            Statement cmd = cn.createStatement();
-            Logs.write(Logs.Level.TRACE, queryInserts.toString());
-            boolean hasResults = cmd.execute(queryInserts.toString());
-            do {
-                if (hasResults) {
-                    try (ResultSet rs = cmd.getResultSet()) {
-                        tablesData = RowSetProvider.newFactory().createCachedRowSet();
-                        tablesData.populate(rs);
-                        tablesData.beforeFirst();
-                        ArrayNode inserts = mapper.createArrayNode();
-                        while (tablesData.next()) {
-                            hasRows = true;
-                            ObjectNode record = mapper.createObjectNode();
-                            ResultSetMetaData rsmd = tablesData.getMetaData();
-                            for (int i = 1; i <= rsmd.getColumnCount(); i++) {
-                                String columnName = rsmd.getColumnName(i);
-                                String colDataType = rsmd.getColumnTypeName(i);
-                                String colValue = tablesData.getString(i);
-                                Boolean wasNull = tablesData.wasNull();
-                                recordMapper.writeColumn(record, columnName, colDataType, colValue, wasNull);
-                            }
-                            inserts.add(record);
-                            addedRecords++;
-                            if(addedRecords == Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE))
-                                break;
-                        }
-                        root.set("inserts", inserts);
+        tableSync.RowsCount = changeSet.RowsCount.toString();
+        tableSync.Records = changeSet.Records;
 
-                    } catch (Exception e) {
-                        Logs.write(Logs.Level.ERROR, "EnumerateChanges() " + e.getMessage());
-                    }
-                }
-
-                hasResults = cmd.getMoreResults();
-
-            } while (hasResults || cmd.getUpdateCount() != -1);
-
-        } catch (SQLException e) {
-            Logs.write(Logs.Level.ERROR, "EnumerateChanges() " + e.getMessage());
-        } finally {
-            JDBCCloser.close(cn);
-        }
-
-        if(addedRecords != Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE)) {
-            cn = Database.getInstance().GetDBConnection();
-            //updates
-            try {
-
-                Statement cmd = cn.createStatement();
-                Logs.write(Logs.Level.TRACE, queryUpdates.toString());
-                boolean hasResults = cmd.execute(queryUpdates.toString());
-                do {
-                    if (hasResults) {
-                        try (ResultSet rs = cmd.getResultSet()) {
-                            tablesDataUpdates = RowSetProvider.newFactory().createCachedRowSet();
-                            tablesDataUpdates.populate(rs);
-                            tablesDataUpdates.beforeFirst();
-                            ArrayNode updates = mapper.createArrayNode();
-                            while (tablesDataUpdates.next()) {
-                                ObjectNode record = mapper.createObjectNode();
-                                ResultSetMetaData rsmd = tablesDataUpdates.getMetaData();
-                                hasRows = true;
-                                for (int i = 1; i <= rsmd.getColumnCount(); i++) {
-                                    String columnName = rsmd.getColumnName(i);
-                                    String colDataType = rsmd.getColumnTypeName(i);
-                                    String colValue = tablesDataUpdates.getString(i);
-                                    Boolean wasNull = tablesDataUpdates.wasNull();
-                                    recordMapper.writeColumn(record, columnName, colDataType, colValue, wasNull);
-                                }
-                                updates.add(record);
-                                addedRecords++;
-                            }
-                            root.set("updates", updates);
-                        } catch (Exception e) {
-                            Logs.write(Logs.Level.ERROR, "EnumarateChanges() updates " + e.getMessage());
-                        }
-                    }
-
-                    hasResults = cmd.getMoreResults();
-
-                } while (hasResults || cmd.getUpdateCount() != -1);
-
-            } catch (SQLException e) {
-                Logs.write(Logs.Level.ERROR, "EnumarateChanges() updates " + e.getMessage());
-            } finally {
-                JDBCCloser.close(cn);
-            }
-        }
-
-        if(addedRecords != Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE)) {
-            cn = Database.getInstance().GetDBConnection();
-            //deletes
-            try {
-                Statement cmd = cn.createStatement();
-                Logs.write(Logs.Level.TRACE, queryDeletes.toString());
-                boolean hasResults = cmd.execute(queryDeletes.toString());
-                do {
-                    if (hasResults) {
-                        try (ResultSet rs = cmd.getResultSet()) {
-                            tablesDataDeletes = RowSetProvider.newFactory().createCachedRowSet();
-                            tablesDataDeletes.populate(rs);
-                            tablesDataDeletes.beforeFirst();
-                            ArrayNode deletes = mapper.createArrayNode();
-                            while (tablesDataDeletes.next()) {
-                                hasRows = true;
-                                deletes.add(mapper.createObjectNode().put("rowid", tablesDataDeletes.getString(1)));
-                                addedRecords++;
-                            }
-                            root.set("deletes", deletes);
-                        } catch (Exception e) {
-                            Logs.write(Logs.Level.ERROR, "EnumarateChanges() deletes " + e.getMessage());
-                        }
-                    }
-
-                    hasResults = cmd.getMoreResults();
-
-                } while (hasResults || cmd.getUpdateCount() != -1);
-
-            } catch (SQLException e) {
-                Logs.write(Logs.Level.ERROR, "EnumarateChanges() deletes " + e.getMessage());
-            } finally {
-                JDBCCloser.close(cn);
-            }
-        }
-
-        tableSync.RowsCount = Integer.toString(addedRecords);
-        tableSync.Records = root;
-        if (hasRows)
+        if (changeSet.HasRows)
             dataToSync.add(tableSync);
+
     }
 
     public void CommitSync(String syncId, String schema) {


### PR DESCRIPTION
## Summary

Extracts pull change query execution and record mapping from `SyncService` into `PullChangeEnumerator`.

This keeps the high-level `sync-compressed` flow in `SyncService`, while moving the technical insert/update/delete result handling into a dedicated class.

## Changes

- added `PullChangeSet` as a result object for pulled changes,
- added `PullChangeEnumerator` to execute prepared insert/update/delete pull queries,
- moved `ResultSet` / `CachedRowSet` to JSON `Records` mapping out of `SyncService`,

## Notes

 
`SyncService` still assigns the returned rowsets back to `tablesData`, `tablesDataUpdates`, and `tablesDataDeletes` ,so the existing `.dat` flow used by `StartNewSync` remains unchanged.

## Verification

- `mvn test` - (dev-client regression tests)


## Next PR

I want to make the sync snapshot flow more explicit, so `StartNewSync` no longer depends on `tablesData`, `tablesDataUpdates`, and `tablesDataDeletes` being set as side effects by `EnumerateChanges` - instead EnumerateChanges should return specific objects.