### PR TITLE
Refactor/04 simplify enumerate changes flow

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
@@ -46,7 +46,7 @@ public class PullChangeEnumerator {
                             inserts.add(record);
                             addedRecords++;
 
-                            if (addedRecords == Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE))
+                            if (!hasCapacity(addedRecords))
                                 break;
                         }
 
@@ -64,7 +64,7 @@ public class PullChangeEnumerator {
             JDBCCloser.close(cn);
         }
 
-        if (addedRecords != Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE)) {
+        if (hasCapacity(addedRecords)) {
             cn = Database.getInstance().GetDBConnection();
             try {
                 Statement cmd = cn.createStatement();
@@ -101,7 +101,7 @@ public class PullChangeEnumerator {
             }
         }
 
-        if (addedRecords != Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE)) {
+        if (hasCapacity(addedRecords)) {
             cn = Database.getInstance().GetDBConnection();
             try {
                 Statement cmd = cn.createStatement();
@@ -155,6 +155,10 @@ public class PullChangeEnumerator {
         }
 
         return record;
+    }
+
+    private boolean hasCapacity(int addedRecords) {
+        return addedRecords != Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE);
     }
 
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
@@ -25,11 +25,11 @@ public class PullChangeEnumerator {
 
         int addedRecords = enumerateInserts(changeSet, root, mapper, queryInserts);
 
-        if (hasCapacity(addedRecords)) {
+        if (!isPackageSizeReached(addedRecords)) {
             addedRecords = enumerateUpdates(changeSet, root, mapper, queryUpdates, addedRecords);
         }
 
-        if (hasCapacity(addedRecords)) {
+        if (!isPackageSizeReached(addedRecords)) {
             addedRecords = enumerateDeletes(changeSet, root, mapper, queryDeletes, addedRecords);
         }
 
@@ -75,7 +75,7 @@ public class PullChangeEnumerator {
                             inserts.add(record);
                             addedRecords++;
 
-                            if (!hasCapacity(addedRecords))
+                            if (isPackageSizeReached(addedRecords))
                                 break;
                         }
 
@@ -170,8 +170,8 @@ public class PullChangeEnumerator {
         return addedRecords;
     }
 
-    private boolean hasCapacity(int addedRecords) {
-        return addedRecords != Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE);
+    private boolean isPackageSizeReached(int addedRecords) {
+        return addedRecords == Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE);
     }
 
     private CachedRowSet cacheResultSet(ResultSet rs) throws SQLException {

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
@@ -7,13 +7,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import javax.sql.rowset.CachedRowSet;
 import javax.sql.rowset.RowSetProvider;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import javax.sql.rowset.CachedRowSet;
+
 
 
 public class PullChangeEnumerator {
@@ -34,9 +35,7 @@ public class PullChangeEnumerator {
             do {
                 if (hasResults) {
                     try (ResultSet rs = cmd.getResultSet()) {
-                        changeSet.Inserts = RowSetProvider.newFactory().createCachedRowSet();
-                        changeSet.Inserts.populate(rs);
-                        changeSet.Inserts.beforeFirst();
+                        changeSet.Inserts = cacheResultSet(rs);
 
                         ArrayNode inserts = mapper.createArrayNode();
                         while (changeSet.Inserts.next()) {
@@ -73,9 +72,7 @@ public class PullChangeEnumerator {
                 do {
                     if (hasResults) {
                         try (ResultSet rs = cmd.getResultSet()) {
-                            changeSet.Updates = RowSetProvider.newFactory().createCachedRowSet();
-                            changeSet.Updates.populate(rs);
-                            changeSet.Updates.beforeFirst();
+                            changeSet.Updates = cacheResultSet(rs);
 
                             ArrayNode updates = mapper.createArrayNode();
                             while (changeSet.Updates.next()) {
@@ -110,9 +107,7 @@ public class PullChangeEnumerator {
                 do {
                     if (hasResults) {
                         try (ResultSet rs = cmd.getResultSet()) {
-                            changeSet.Deletes = RowSetProvider.newFactory().createCachedRowSet();
-                            changeSet.Deletes.populate(rs);
-                            changeSet.Deletes.beforeFirst();
+                            changeSet.Deletes = cacheResultSet(rs);
 
                             ArrayNode deletes = mapper.createArrayNode();
                             while (changeSet.Deletes.next()) {
@@ -161,4 +156,10 @@ public class PullChangeEnumerator {
         return addedRecords != Integer.parseInt(SQLiteSyncConfig.PACKAGE_SIZE);
     }
 
+    private CachedRowSet cacheResultSet(ResultSet rs) throws SQLException {
+        CachedRowSet rowSet = RowSetProvider.newFactory().createCachedRowSet();
+        rowSet.populate(rs);
+        rowSet.beforeFirst();
+        return rowSet;
+    }
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
@@ -25,46 +25,12 @@ public class PullChangeEnumerator {
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode root = mapper.createObjectNode();
 
-        int addedRecords = 0;
+        int addedRecords = enumerateInserts(changeSet, root, mapper, queryInserts);
 
-        Connection cn = Database.getInstance().GetDBConnection();
-        try {
-            Statement cmd = cn.createStatement();
-            Logs.write(Logs.Level.TRACE, queryInserts.toString());
-            boolean hasResults = cmd.execute(queryInserts.toString());
-            do {
-                if (hasResults) {
-                    try (ResultSet rs = cmd.getResultSet()) {
-                        changeSet.Inserts = cacheResultSet(rs);
-
-                        ArrayNode inserts = mapper.createArrayNode();
-                        while (changeSet.Inserts.next()) {
-                            changeSet.HasRows = true;
-                            ObjectNode record = mapCurrentRecord(changeSet.Inserts, mapper);
-
-                            inserts.add(record);
-                            addedRecords++;
-
-                            if (!hasCapacity(addedRecords))
-                                break;
-                        }
-
-                        root.set("inserts", inserts);
-                    } catch (Exception e) {
-                        Logs.write(Logs.Level.ERROR, "EnumerateChanges() " + e.getMessage());
-                    }
-                }
-
-                hasResults = cmd.getMoreResults();
-            } while (hasResults || cmd.getUpdateCount() != -1);
-        } catch (SQLException e) {
-            Logs.write(Logs.Level.ERROR, "EnumerateChanges() " + e.getMessage());
-        } finally {
-            JDBCCloser.close(cn);
-        }
 
         if (hasCapacity(addedRecords)) {
-            cn = Database.getInstance().GetDBConnection();
+            Connection cn = Database.getInstance().GetDBConnection();
+
             try {
                 Statement cmd = cn.createStatement();
                 Logs.write(Logs.Level.TRACE, queryUpdates.toString());
@@ -99,7 +65,8 @@ public class PullChangeEnumerator {
         }
 
         if (hasCapacity(addedRecords)) {
-            cn = Database.getInstance().GetDBConnection();
+            Connection cn = Database.getInstance().GetDBConnection();
+
             try {
                 Statement cmd = cn.createStatement();
                 Logs.write(Logs.Level.TRACE, queryDeletes.toString());
@@ -150,6 +117,48 @@ public class PullChangeEnumerator {
         }
 
         return record;
+    }
+
+    private int enumerateInserts(PullChangeSet changeSet, ObjectNode root, ObjectMapper mapper, StringBuilder queryInserts) {
+        int addedRecords = 0;
+
+        Connection cn = Database.getInstance().GetDBConnection();
+        try {
+            Statement cmd = cn.createStatement();
+            Logs.write(Logs.Level.TRACE, queryInserts.toString());
+            boolean hasResults = cmd.execute(queryInserts.toString());
+            do {
+                if (hasResults) {
+                    try (ResultSet rs = cmd.getResultSet()) {
+                        changeSet.Inserts = cacheResultSet(rs);
+
+                        ArrayNode inserts = mapper.createArrayNode();
+                        while (changeSet.Inserts.next()) {
+                            changeSet.HasRows = true;
+                            ObjectNode record = mapCurrentRecord(changeSet.Inserts, mapper);
+
+                            inserts.add(record);
+                            addedRecords++;
+
+                            if (!hasCapacity(addedRecords))
+                                break;
+                        }
+
+                        root.set("inserts", inserts);
+                    } catch (Exception e) {
+                        Logs.write(Logs.Level.ERROR, "EnumerateChanges() " + e.getMessage());
+                    }
+                }
+
+                hasResults = cmd.getMoreResults();
+            } while (hasResults || cmd.getUpdateCount() != -1);
+        } catch (SQLException e) {
+            Logs.write(Logs.Level.ERROR, "EnumerateChanges() " + e.getMessage());
+        } finally {
+            JDBCCloser.close(cn);
+        }
+
+        return addedRecords;
     }
 
     private boolean hasCapacity(int addedRecords) {

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
@@ -13,6 +13,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import javax.sql.rowset.CachedRowSet;
+
 
 public class PullChangeEnumerator {
     private final SyncRecordMapper recordMapper = new SyncRecordMapper();
@@ -39,17 +41,7 @@ public class PullChangeEnumerator {
                         ArrayNode inserts = mapper.createArrayNode();
                         while (changeSet.Inserts.next()) {
                             changeSet.HasRows = true;
-                            ObjectNode record = mapper.createObjectNode();
-                            ResultSetMetaData rsmd = changeSet.Inserts.getMetaData();
-
-                            for (int i = 1; i <= rsmd.getColumnCount(); i++) {
-                                String columnName = rsmd.getColumnName(i);
-                                String colDataType = rsmd.getColumnTypeName(i);
-                                String colValue = changeSet.Inserts.getString(i);
-                                Boolean wasNull = changeSet.Inserts.wasNull();
-
-                                recordMapper.writeColumn(record, columnName, colDataType, colValue, wasNull);
-                            }
+                            ObjectNode record = mapCurrentRecord(changeSet.Inserts, mapper);
 
                             inserts.add(record);
                             addedRecords++;
@@ -87,18 +79,8 @@ public class PullChangeEnumerator {
 
                             ArrayNode updates = mapper.createArrayNode();
                             while (changeSet.Updates.next()) {
-                                ObjectNode record = mapper.createObjectNode();
-                                ResultSetMetaData rsmd = changeSet.Updates.getMetaData();
                                 changeSet.HasRows = true;
-
-                                for (int i = 1; i <= rsmd.getColumnCount(); i++) {
-                                    String columnName = rsmd.getColumnName(i);
-                                    String colDataType = rsmd.getColumnTypeName(i);
-                                    String colValue = changeSet.Updates.getString(i);
-                                    Boolean wasNull = changeSet.Updates.wasNull();
-
-                                    recordMapper.writeColumn(record, columnName, colDataType, colValue, wasNull);
-                                }
+                                ObjectNode record = mapCurrentRecord(changeSet.Updates, mapper);
 
                                 updates.add(record);
                                 addedRecords++;
@@ -158,4 +140,21 @@ public class PullChangeEnumerator {
         changeSet.Records = root;
         return changeSet;
     }
+
+    private ObjectNode mapCurrentRecord(CachedRowSet rowSet, ObjectMapper mapper) throws SQLException {
+        ObjectNode record = mapper.createObjectNode();
+        ResultSetMetaData rsmd = rowSet.getMetaData();
+
+        for (int i = 1; i <= rsmd.getColumnCount(); i++) {
+            String columnName = rsmd.getColumnName(i);
+            String colDataType = rsmd.getColumnTypeName(i);
+            String colValue = rowSet.getString(i);
+            Boolean wasNull = rowSet.wasNull();
+
+            recordMapper.writeColumn(record, columnName, colDataType, colValue, wasNull);
+        }
+
+        return record;
+    }
+
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
@@ -15,8 +15,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-
-
 public class PullChangeEnumerator {
     private final SyncRecordMapper recordMapper = new SyncRecordMapper();
 
@@ -27,75 +25,12 @@ public class PullChangeEnumerator {
 
         int addedRecords = enumerateInserts(changeSet, root, mapper, queryInserts);
 
-
         if (hasCapacity(addedRecords)) {
-            Connection cn = Database.getInstance().GetDBConnection();
-
-            try {
-                Statement cmd = cn.createStatement();
-                Logs.write(Logs.Level.TRACE, queryUpdates.toString());
-                boolean hasResults = cmd.execute(queryUpdates.toString());
-                do {
-                    if (hasResults) {
-                        try (ResultSet rs = cmd.getResultSet()) {
-                            changeSet.Updates = cacheResultSet(rs);
-
-                            ArrayNode updates = mapper.createArrayNode();
-                            while (changeSet.Updates.next()) {
-                                changeSet.HasRows = true;
-                                ObjectNode record = mapCurrentRecord(changeSet.Updates, mapper);
-
-                                updates.add(record);
-                                addedRecords++;
-                            }
-
-                            root.set("updates", updates);
-                        } catch (Exception e) {
-                            Logs.write(Logs.Level.ERROR, "EnumarateChanges() updates " + e.getMessage());
-                        }
-                    }
-
-                    hasResults = cmd.getMoreResults();
-                } while (hasResults || cmd.getUpdateCount() != -1);
-            } catch (SQLException e) {
-                Logs.write(Logs.Level.ERROR, "EnumarateChanges() updates " + e.getMessage());
-            } finally {
-                JDBCCloser.close(cn);
-            }
+            addedRecords = enumerateUpdates(changeSet, root, mapper, queryUpdates, addedRecords);
         }
 
         if (hasCapacity(addedRecords)) {
-            Connection cn = Database.getInstance().GetDBConnection();
-
-            try {
-                Statement cmd = cn.createStatement();
-                Logs.write(Logs.Level.TRACE, queryDeletes.toString());
-                boolean hasResults = cmd.execute(queryDeletes.toString());
-                do {
-                    if (hasResults) {
-                        try (ResultSet rs = cmd.getResultSet()) {
-                            changeSet.Deletes = cacheResultSet(rs);
-
-                            ArrayNode deletes = mapper.createArrayNode();
-                            while (changeSet.Deletes.next()) {
-                                changeSet.HasRows = true;
-                                deletes.add(mapper.createObjectNode().put("rowid", changeSet.Deletes.getString(1)));
-                                addedRecords++;
-                            }
-
-                            root.set("deletes", deletes);
-                        } catch (Exception e) {
-                            Logs.write(Logs.Level.ERROR, "EnumarateChanges() deletes " + e.getMessage());
-                        }
-                    }
-
-                    hasResults = cmd.getMoreResults();
-                } while (hasResults || cmd.getUpdateCount() != -1);
-            } catch (SQLException e) {
-                Logs.write(Logs.Level.ERROR, "EnumarateChanges() deletes " + e.getMessage());
-            } finally {
-                JDBCCloser.close(cn);
-            }
+            addedRecords = enumerateDeletes(changeSet, root, mapper, queryDeletes, addedRecords);
         }
 
         changeSet.RowsCount = addedRecords;
@@ -154,6 +89,80 @@ public class PullChangeEnumerator {
             } while (hasResults || cmd.getUpdateCount() != -1);
         } catch (SQLException e) {
             Logs.write(Logs.Level.ERROR, "EnumerateChanges() " + e.getMessage());
+        } finally {
+            JDBCCloser.close(cn);
+        }
+
+        return addedRecords;
+    }
+
+    private int enumerateUpdates(PullChangeSet changeSet, ObjectNode root, ObjectMapper mapper, StringBuilder queryUpdates, int addedRecords) {
+        Connection cn = Database.getInstance().GetDBConnection();
+
+        try {
+            Statement cmd = cn.createStatement();
+            Logs.write(Logs.Level.TRACE, queryUpdates.toString());
+            boolean hasResults = cmd.execute(queryUpdates.toString());
+            do {
+                if (hasResults) {
+                    try (ResultSet rs = cmd.getResultSet()) {
+                        changeSet.Updates = cacheResultSet(rs);
+
+                        ArrayNode updates = mapper.createArrayNode();
+                        while (changeSet.Updates.next()) {
+                            changeSet.HasRows = true;
+                            ObjectNode record = mapCurrentRecord(changeSet.Updates, mapper);
+
+                            updates.add(record);
+                            addedRecords++;
+                        }
+
+                        root.set("updates", updates);
+                    } catch (Exception e) {
+                        Logs.write(Logs.Level.ERROR, "EnumarateChanges() updates " + e.getMessage());
+                    }
+                }
+
+                hasResults = cmd.getMoreResults();
+            } while (hasResults || cmd.getUpdateCount() != -1);
+        } catch (SQLException e) {
+            Logs.write(Logs.Level.ERROR, "EnumarateChanges() updates " + e.getMessage());
+        } finally {
+            JDBCCloser.close(cn);
+        }
+
+        return addedRecords;
+    }
+
+    private int enumerateDeletes(PullChangeSet changeSet, ObjectNode root, ObjectMapper mapper, StringBuilder queryDeletes, int addedRecords) {
+        Connection cn = Database.getInstance().GetDBConnection();
+
+        try {
+            Statement cmd = cn.createStatement();
+            Logs.write(Logs.Level.TRACE, queryDeletes.toString());
+            boolean hasResults = cmd.execute(queryDeletes.toString());
+            do {
+                if (hasResults) {
+                    try (ResultSet rs = cmd.getResultSet()) {
+                        changeSet.Deletes = cacheResultSet(rs);
+
+                        ArrayNode deletes = mapper.createArrayNode();
+                        while (changeSet.Deletes.next()) {
+                            changeSet.HasRows = true;
+                            deletes.add(mapper.createObjectNode().put("rowid", changeSet.Deletes.getString(1)));
+                            addedRecords++;
+                        }
+
+                        root.set("deletes", deletes);
+                    } catch (Exception e) {
+                        Logs.write(Logs.Level.ERROR, "EnumarateChanges() deletes " + e.getMessage());
+                    }
+                }
+
+                hasResults = cmd.getMoreResults();
+            } while (hasResults || cmd.getUpdateCount() != -1);
+        } catch (SQLException e) {
+            Logs.write(Logs.Level.ERROR, "EnumarateChanges() deletes " + e.getMessage());
         } finally {
             JDBCCloser.close(cn);
         }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullFilter.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullFilter.java
@@ -1,0 +1,6 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+public class PullFilter {
+    public String View;
+    public String ChangeDetectionCondition;
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -138,9 +138,25 @@ public class SyncService {
         return syncId;
     }
 
+    private void AddSyncTriggers(DataObject tableSync, String tableName, String tableSchema) {
+        if (tableName.equalsIgnoreCase("mergeidentity")) {
+            return;
+        }
+
+        SchemaGenerator schemaGenerator = new SchemaGenerator();
+        DatabaseTable table = DatabaseTableGuavaCacheUtil.getTableUsingGuava(tableName, tableSchema);
+
+        tableSync.TriggerInsert = "select 1;";
+        tableSync.TriggerInsertDrop = "select 1;";
+        tableSync.TriggerUpdate = schemaGenerator.CreateUpdateTrigger(table, schemaGenerator.GenerateUpdateableColumns(table.Columns));
+        tableSync.TriggerUpdateDrop = "drop trigger if exists \"trmergeupdate_" + tableName + "\"";
+        tableSync.TriggerDelete = schemaGenerator.CreateDeleteTrigger(table);
+        tableSync.TriggerDeleteDrop = "drop trigger if exists \"trmergedelete_" + tableName + "\"";
+    }
+
+
     private void EnumerateChanges(String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
         DataObject tableSync = new DataObject();
-        boolean hasRows = false;
         tableSync.TableName = tableName;
         tableSync.MaxPackageSize = SQLiteSyncConfig.PACKAGE_SIZE;
         sqLiteClientQueryBuilder.buildQueries(tableSync, tableSchema);
@@ -168,17 +184,7 @@ public class SyncService {
         StringBuilder queryUpdates = pullQueryBuilder.buildUpdateChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD);
         StringBuilder queryDeletes = pullQueryBuilder.buildDeleteChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
 
-        SchemaGenerator schemaGenerator = new SchemaGenerator();
-
-        DatabaseTable table = DatabaseTableGuavaCacheUtil.getTableUsingGuava(tableName, tableSchema);
-        if (!tableName.equalsIgnoreCase("mergeidentity")) {
-            tableSync.TriggerInsert =  "select 1;";
-            tableSync.TriggerInsertDrop = "select 1;";
-            tableSync.TriggerUpdate = schemaGenerator.CreateUpdateTrigger(table, schemaGenerator.GenerateUpdateableColumns(table.Columns));
-            tableSync.TriggerUpdateDrop = "drop trigger if exists \"trmergeupdate_" + tableName + "\"";
-            tableSync.TriggerDelete = schemaGenerator.CreateDeleteTrigger(table);
-            tableSync.TriggerDeleteDrop = "drop trigger if exists \"trmergedelete_" + tableName + "\"";
-        }
+        AddSyncTriggers(tableSync, tableName, tableSchema);
 
         PullChangeSet changeSet = pullChangeEnumerator.enumerate(queryInserts, queryUpdates, queryDeletes);
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -154,35 +154,46 @@ public class SyncService {
         tableSync.TriggerDeleteDrop = "drop trigger if exists \"trmergedelete_" + tableName + "\"";
     }
 
+    private PullFilter BuildPullFilter(String tableSchema, String tableName, String tableFilter, String subscriberUUID, String subscriberId) {
+        PullFilter pullFilter = new PullFilter();
+
+        pullFilter.View = tableSchema + "." + tableName;
+
+        if (tableSchema == null || tableSchema.isEmpty())
+            pullFilter.View = tableName;
+
+        pullFilter.ChangeDetectionCondition = " ";
+
+        if (tableFilter != null && tableFilter.trim().length() > 0) {
+            pullFilter.View = tableFilter;
+            if (pullFilter.View.startsWith("public.fn_") || pullFilter.View.startsWith("fn_")) {
+                pullFilter.View = pullFilter.View.replace("@incomming_uniquename", subscriberUUID);
+                pullFilter.ChangeDetectionCondition = " ";
+            } else {
+                pullFilter.ChangeDetectionCondition = "and vw.uniquename='" + subscriberUUID + "' ";
+            }
+
+            if (tableName.equalsIgnoreCase("mergeidentity"))
+                pullFilter.ChangeDetectionCondition += " and tb.SubscriberId= " + subscriberId + " ";
+
+            Logs.write(Logs.Level.TRACE, "Using filter [" + tableFilter + "] for table " + tableName);
+        }
+
+        return pullFilter;
+    }
+
 
     private void EnumerateChanges(String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
         DataObject tableSync = new DataObject();
         tableSync.TableName = tableName;
         tableSync.MaxPackageSize = SQLiteSyncConfig.PACKAGE_SIZE;
         sqLiteClientQueryBuilder.buildQueries(tableSync, tableSchema);
-        String filterVW = tableSchema + "." + tableName;
 
-        if (tableSchema == null || tableSchema.isEmpty())
-            filterVW = tableName;
+        PullFilter pullFilter = BuildPullFilter(tableSchema, tableName, tableFilter, subscriberUUID, subscriberId);
 
-        String filterVW_CD = " ";
-
-        if (tableFilter != null && tableFilter.trim().length() > 0) {
-            filterVW = tableFilter;
-            if(filterVW.startsWith("public.fn_") || filterVW.startsWith("fn_")) {
-                filterVW = filterVW.replace("@incomming_uniquename", subscriberUUID);
-                filterVW_CD = " ";
-            }
-            else
-                filterVW_CD = "and vw.uniquename='" + subscriberUUID + "' ";
-            if(tableName.equalsIgnoreCase("mergeidentity"))
-                filterVW_CD += " and tb.SubscriberId= " + subscriberId + " ";
-            Logs.write(Logs.Level.TRACE, "Using filter [" + tableFilter + "] for table " + tableName);
-        }
-
-        StringBuilder queryInserts = pullQueryBuilder.buildInsertChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
-        StringBuilder queryUpdates = pullQueryBuilder.buildUpdateChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD);
-        StringBuilder queryDeletes = pullQueryBuilder.buildDeleteChangesQuery(subscriberId, tableSchema, tableName, filterVW, filterVW_CD, subscriberUUID);
+        StringBuilder queryInserts = pullQueryBuilder.buildInsertChangesQuery(subscriberId, tableSchema, tableName, pullFilter.View, pullFilter.ChangeDetectionCondition, subscriberUUID);
+        StringBuilder queryUpdates = pullQueryBuilder.buildUpdateChangesQuery(subscriberId, tableSchema, tableName, pullFilter.View, pullFilter.ChangeDetectionCondition);
+        StringBuilder queryDeletes = pullQueryBuilder.buildDeleteChangesQuery(subscriberId, tableSchema, tableName, pullFilter.View, pullFilter.ChangeDetectionCondition, subscriberUUID);
 
         AddSyncTriggers(tableSync, tableName, tableSchema);
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -9,13 +9,11 @@ import com.ampliapps.amplisync.SyncServer.SchemaPublish.SchemaGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Stopwatch;
 import org.postgresql.util.PGobject;
 
 import javax.sql.rowset.CachedRowSet;
-import javax.sql.rowset.RowSetProvider;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
@@ -35,7 +33,6 @@ public class SyncService {
     public Integer syncIdForTestPurpose = -1;
     List<DataObject> dataToSync = new ArrayList<>();
     private final SQLQueries QUERIES = new SQLQueries();
-    private final SyncRecordMapper recordMapper = new SyncRecordMapper();
     private final PullQueryBuilder pullQueryBuilder = new PullQueryBuilder();
     private final SyncSessionStore syncSessionStore = new SyncSessionStore();
     private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
@@ -76,7 +73,7 @@ public class SyncService {
                 tableId = reader.getInt("tableid");
                 tableSchema = reader.getString("tableschema");
                 String tableFilter = reader.getString("tablefilter");
-                EnumerateChanges(reader.getString("tableid"), subscriberId, reader.getString("tablename"), tableSchema, tableFilter, subscriberUUID);
+                enumerateChanges(reader.getString("tableid"), subscriberId, reader.getString("tablename"), tableSchema, tableFilter, subscriberUUID);
             } else
                 Logs.write(Logs.Level.INFO, "DoSync(). Table " + schema + "." + tableName + " was not found in MergeTablesToSync.");
 
@@ -138,7 +135,7 @@ public class SyncService {
         return syncId;
     }
 
-    private void AddSyncTriggers(DataObject tableSync, String tableName, String tableSchema) {
+    private void addSyncTriggers(DataObject tableSync, String tableName, String tableSchema) {
         if (tableName.equalsIgnoreCase("mergeidentity")) {
             return;
         }
@@ -154,7 +151,7 @@ public class SyncService {
         tableSync.TriggerDeleteDrop = "drop trigger if exists \"trmergedelete_" + tableName + "\"";
     }
 
-    private PullFilter BuildPullFilter(String tableSchema, String tableName, String tableFilter, String subscriberUUID, String subscriberId) {
+    private PullFilter buildPullFilter(String tableSchema, String tableName, String tableFilter, String subscriberUUID, String subscriberId) {
         PullFilter pullFilter = new PullFilter();
 
         pullFilter.View = tableSchema + "." + tableName;
@@ -183,19 +180,20 @@ public class SyncService {
     }
 
 
-    private void EnumerateChanges(String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
+    private void enumerateChanges(String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
         DataObject tableSync = new DataObject();
         tableSync.TableName = tableName;
         tableSync.MaxPackageSize = SQLiteSyncConfig.PACKAGE_SIZE;
+
         sqLiteClientQueryBuilder.buildQueries(tableSync, tableSchema);
 
-        PullFilter pullFilter = BuildPullFilter(tableSchema, tableName, tableFilter, subscriberUUID, subscriberId);
+        PullFilter pullFilter = buildPullFilter(tableSchema, tableName, tableFilter, subscriberUUID, subscriberId);
 
         StringBuilder queryInserts = pullQueryBuilder.buildInsertChangesQuery(subscriberId, tableSchema, tableName, pullFilter.View, pullFilter.ChangeDetectionCondition, subscriberUUID);
         StringBuilder queryUpdates = pullQueryBuilder.buildUpdateChangesQuery(subscriberId, tableSchema, tableName, pullFilter.View, pullFilter.ChangeDetectionCondition);
         StringBuilder queryDeletes = pullQueryBuilder.buildDeleteChangesQuery(subscriberId, tableSchema, tableName, pullFilter.View, pullFilter.ChangeDetectionCondition, subscriberUUID);
 
-        AddSyncTriggers(tableSync, tableName, tableSchema);
+        addSyncTriggers(tableSync, tableName, tableSchema);
 
         PullChangeSet changeSet = pullChangeEnumerator.enumerate(queryInserts, queryUpdates, queryDeletes);
 


### PR DESCRIPTION
## Summary

Refactors the pull change enumeration flow used by the sync-compressed endpoint. ( `PullChangeEnumerator extracted from SyncService in previous PR 105).

`PullChangeEnumerator.enumerate()` method is now more linear, with insert, update, and delete handling moved into dedicated helper methods. The change is intended to improve readability without changing endpoint behavior.

## Changes

- Extracted insert, update, and delete enumeration into separate methods.
- Extracted cached result set creation into a helper.
- Extracted row-to-record mapping.
- Extracted package-size capacity check.
- Extracted pull filter setup.
- Extracted sync trigger setup.
- No business logic changes.

## Testing

 - Regression sync tests pass locally.
 
## Next PRs
will continue the sync-compressed cleanup by making the data flow between `enumerateChanges()` and `StartNewSync()` more explicit and reducing  hidden state in `SyncService`. In  later PR, I also  make `PullFilter` a local record
  inside `SyncService`, instead of separate class file.
