### PR TITLE
Refactor/05 sync compressed reduce hidden states

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
@@ -318,8 +318,14 @@ public class SQLitePrepopulate {
 
                 trCreate.executeBatch();
             }
-            syncService.tablesData = tablesData;
-            Integer syncId = syncService.StartNewSync(subscriberId, Integer.parseInt(tableId), tableSchema);
+            Integer syncId = syncService.StartNewSync(
+                    subscriberId,
+                    Integer.parseInt(tableId),
+                    tableSchema,
+                    tablesData,
+                    null,
+                    null
+            );
             syncService.CommitSync(syncId.toString(), tableSchema);
         } catch (SQLException e) {
             Logs.write(Logs.Level.ERROR, "EnumerateChanges(): " + tableName + ". " + e.getMessage());

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -37,9 +37,6 @@ public class SyncService {
     private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
     private final SQLiteClientQueryBuilder sqLiteClientQueryBuilder = new SQLiteClientQueryBuilder();
     private final PullChangeEnumerator pullChangeEnumerator = new PullChangeEnumerator();
-    public CachedRowSet tablesData = null;
-    public CachedRowSet tablesDataUpdates = null;
-    public CachedRowSet tablesDataDeletes = null;
 
     public SyncService() {
         SQLiteSyncConfig.Load();
@@ -81,12 +78,17 @@ public class SyncService {
             } else
                 Logs.write(Logs.Level.INFO, "DoSync(). Table " + schema + "." + tableName + " was not found in MergeTablesToSync.");
 
-            Integer syncId = StartPullSync(
+            PullChangeSet changeSet = changes != null ? changes.pullChangeSet : null;
+
+            Integer syncId = StartNewSync(
                     subscriberId,
                     tableId,
                     tableSchema,
-                    changes != null ? changes.pullChangeSet : null
+                    changeSet != null ? changeSet.Inserts : null,
+                    changeSet != null ? changeSet.Updates : null,
+                    changeSet != null ? changeSet.Deletes : null
             );
+
             this.syncIdForTestPurpose = syncId;
             for (DataObject obj : dataToSync) {
                 obj.SyncId = syncId;
@@ -126,7 +128,15 @@ public class SyncService {
         return stringEmp.toString();
     }
 
-    public Integer StartNewSync(String subscriberId, Integer tableId, String schema) {
+
+    public Integer StartNewSync(
+            String subscriberId,
+            Integer tableId,
+            String schema,
+            CachedRowSet inserts,
+            CachedRowSet updates,
+            CachedRowSet deletes
+    ) {
 
         File theDir = new File(SQLiteSyncConfig.WORKING_DIR + "SyncData");
         if (!theDir.exists()) {
@@ -139,34 +149,10 @@ public class SyncService {
 
         Integer syncId = syncSessionRepository.startSync(subscriberId, tableId, schema);
 
-        syncSessionStore.writeSyncData(syncId.toString(), tablesData, tablesDataUpdates, tablesDataDeletes);
+        syncSessionStore.writeSyncData(syncId.toString(), inserts, updates, deletes);
 
         return syncId;
     }
-
-    public Integer StartPullSync(String subscriberId, Integer tableId, String schema, PullChangeSet changeSet) {
-
-        File theDir = new File(SQLiteSyncConfig.WORKING_DIR + "SyncData");
-        if (!theDir.exists()) {
-            try {
-                theDir.mkdir();
-            } catch (SecurityException e) {
-                Logs.write(Logs.Level.ERROR, "StartNewSync()->Creating folder SyncData " + e.getMessage());
-            }
-        }
-
-        Integer syncId = syncSessionRepository.startSync(subscriberId, tableId, schema);
-
-        syncSessionStore.writeSyncData(
-                syncId.toString(),
-                changeSet != null ? changeSet.Inserts : null,
-                changeSet != null ? changeSet.Updates : null,
-                changeSet != null ? changeSet.Deletes : null
-        );
-
-        return syncId;
-    }
-
 
     private void addSyncTriggers(DataObject tableSync, String tableName, String tableSchema) {
         if (tableName.equalsIgnoreCase("mergeidentity")) {

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -31,7 +31,6 @@ import java.util.regex.Pattern;
 public class SyncService {
 
     public Integer syncIdForTestPurpose = -1;
-    List<DataObject> dataToSync = new ArrayList<>();
     private final SQLQueries QUERIES = new SQLQueries();
     private final PullQueryBuilder pullQueryBuilder = new PullQueryBuilder();
     private final SyncSessionStore syncSessionStore = new SyncSessionStore();
@@ -48,6 +47,8 @@ public class SyncService {
 
     public String getChangesForTable(String subscriberUUID, String schema, String tableName, String deviceUUID) {
         Stopwatch stopwatch = Stopwatch.createStarted();
+        List<DataObject> dataToSync = new ArrayList<>();
+        EnumeratedTableChanges changes = null;
         CommonTools common = new CommonTools();
         String subscriberId = common.CheckIfSubscriberExists(subscriberUUID, deviceUUID).toString();
 
@@ -73,7 +74,7 @@ public class SyncService {
                 tableId = reader.getInt("tableid");
                 tableSchema = reader.getString("tableschema");
                 String tableFilter = reader.getString("tablefilter");
-                enumerateChanges(reader.getString("tableid"), subscriberId, reader.getString("tablename"), tableSchema, tableFilter, subscriberUUID);
+                enumerateChanges(dataToSync, reader.getString("tableid"), subscriberId, reader.getString("tablename"), tableSchema, tableFilter, subscriberUUID);
             } else
                 Logs.write(Logs.Level.INFO, "DoSync(). Table " + schema + "." + tableName + " was not found in MergeTablesToSync.");
 
@@ -180,7 +181,7 @@ public class SyncService {
     }
 
 
-    private void enumerateChanges(String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
+    private void enumerateChanges(List<DataObject> dataToSync, String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
         DataObject tableSync = new DataObject();
         tableSync.TableName = tableName;
         tableSync.MaxPackageSize = SQLiteSyncConfig.PACKAGE_SIZE;

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -108,16 +108,9 @@ public class SyncService {
             JDBCCloser.close(cn);
         }
 
+        String syncResponse = serializeSyncResponse(dataToSync);
+        Logs.write(Logs.Level.TRACE, syncResponse);
 
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
-        StringWriter stringEmp = new StringWriter();
-        try {
-            objectMapper.writeValue(stringEmp, dataToSync);
-        } catch (IOException ex) {
-            Logs.write(Logs.Level.ERROR, "DoSync()->JSON Serialization " + ex.getMessage());
-        }
-        Logs.write(Logs.Level.TRACE, stringEmp.toString());
         stopwatch.stop();
         Long stopwatchMilisecs  = stopwatch.elapsed(TimeUnit.MILLISECONDS);
         if(stopwatchMilisecs > 400)
@@ -125,6 +118,20 @@ public class SyncService {
                 Logs.write(Logs.Level.WARN, "Getting changes for subscriber ["+deviceUUID+"]/[" + subscriberId + "] and table [" + tableName + "], no changes. Time elapsed: "+ stopwatchMilisecs);
             else
                 Logs.write(Logs.Level.WARN, "Getting changes for subscriber ["+deviceUUID+"]/[" + subscriberId + "] and table [" + tableName + "], records count [" + dataToSync.get(0).RowsCount + "/" + dataToSync.get(0).MaxPackageSize + "]. Time elapsed: "+ stopwatchMilisecs);
+        return syncResponse;
+    }
+
+    private String serializeSyncResponse(List<DataObject> dataToSync) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(SerializationFeature.INDENT_OUTPUT, true);
+        StringWriter stringEmp = new StringWriter();
+
+        try {
+            objectMapper.writeValue(stringEmp, dataToSync);
+        } catch (IOException ex) {
+            Logs.write(Logs.Level.ERROR, "DoSync()->JSON Serialization " + ex.getMessage());
+        }
+
         return stringEmp.toString();
     }
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -74,11 +74,19 @@ public class SyncService {
                 tableId = reader.getInt("tableid");
                 tableSchema = reader.getString("tableschema");
                 String tableFilter = reader.getString("tablefilter");
-                enumerateChanges(dataToSync, reader.getString("tableid"), subscriberId, reader.getString("tablename"), tableSchema, tableFilter, subscriberUUID);
+                changes = enumerateChanges(reader.getString("tableid"), subscriberId, reader.getString("tablename"), tableSchema, tableFilter, subscriberUUID);
+                if (changes.pullChangeSet.HasRows)
+                    dataToSync.add(changes.tableSync);
+
             } else
                 Logs.write(Logs.Level.INFO, "DoSync(). Table " + schema + "." + tableName + " was not found in MergeTablesToSync.");
 
-            Integer syncId = StartNewSync(subscriberId, tableId, tableSchema);
+            Integer syncId = StartPullSync(
+                    subscriberId,
+                    tableId,
+                    tableSchema,
+                    changes != null ? changes.pullChangeSet : null
+            );
             this.syncIdForTestPurpose = syncId;
             for (DataObject obj : dataToSync) {
                 obj.SyncId = syncId;
@@ -136,6 +144,30 @@ public class SyncService {
         return syncId;
     }
 
+    public Integer StartPullSync(String subscriberId, Integer tableId, String schema, PullChangeSet changeSet) {
+
+        File theDir = new File(SQLiteSyncConfig.WORKING_DIR + "SyncData");
+        if (!theDir.exists()) {
+            try {
+                theDir.mkdir();
+            } catch (SecurityException e) {
+                Logs.write(Logs.Level.ERROR, "StartNewSync()->Creating folder SyncData " + e.getMessage());
+            }
+        }
+
+        Integer syncId = syncSessionRepository.startSync(subscriberId, tableId, schema);
+
+        syncSessionStore.writeSyncData(
+                syncId.toString(),
+                changeSet != null ? changeSet.Inserts : null,
+                changeSet != null ? changeSet.Updates : null,
+                changeSet != null ? changeSet.Deletes : null
+        );
+
+        return syncId;
+    }
+
+
     private void addSyncTriggers(DataObject tableSync, String tableName, String tableSchema) {
         if (tableName.equalsIgnoreCase("mergeidentity")) {
             return;
@@ -180,8 +212,12 @@ public class SyncService {
         return pullFilter;
     }
 
+    private static class EnumeratedTableChanges {
+        private DataObject tableSync;
+        private PullChangeSet pullChangeSet;
+    }
 
-    private void enumerateChanges(List<DataObject> dataToSync, String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
+    private EnumeratedTableChanges enumerateChanges(String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
         DataObject tableSync = new DataObject();
         tableSync.TableName = tableName;
         tableSync.MaxPackageSize = SQLiteSyncConfig.PACKAGE_SIZE;
@@ -198,16 +234,13 @@ public class SyncService {
 
         PullChangeSet changeSet = pullChangeEnumerator.enumerate(queryInserts, queryUpdates, queryDeletes);
 
-        tablesData = changeSet.Inserts;
-        tablesDataUpdates = changeSet.Updates;
-        tablesDataDeletes = changeSet.Deletes;
-
         tableSync.RowsCount = changeSet.RowsCount.toString();
         tableSync.Records = changeSet.Records;
 
-        if (changeSet.HasRows)
-            dataToSync.add(tableSync);
-
+        EnumeratedTableChanges changes = new EnumeratedTableChanges();
+        changes.tableSync = tableSync;
+        changes.pullChangeSet = changeSet;
+        return changes;
     }
 
     public void CommitSync(String syncId, String schema) {


### PR DESCRIPTION
 ## Summary

Continues the sync-compressed refactor by making the data flow between change enumeration and sync session creation more direct.

This PR reduces hidden request-level state in `SyncService`:  `enumerateChanges()` now returns the data it produces, and `StartNewSync()` receives the rowsets, instead of reading them from mutable class fields.

## Changes

- Localized `dataToSync` to `getChangesForTable()`.
- Made `enumerateChanges()` return a result object.
- Passed pull session rowsets explicitly into `StartNewSync()`.
- Removed the now unused `tablesData`, `tablesDataUpdates`, and `tablesDataDeletes` fields from `SyncService`.
- Updated `SQLitePrepopulate` to pass prepopulate data directly,  when  starting a sync session.
- Extracted sync response serialization into a helper.
- No  business logic changes.

## Testing

- Regression sync tests pass locally.
