### PR TITLE
Refactor/06 commit sync flow

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullFilter.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullFilter.java
@@ -1,6 +1,0 @@
-package com.ampliapps.amplisync.SyncServer.Synchronization;
-
-public class PullFilter {
-    public String View;
-    public String ChangeDetectionCondition;
-}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -241,7 +241,7 @@ public class SyncService {
 
         CommitSyncSession session = readCommitSyncSession(syncId, schema);
 
-        UpdateSyncData(Integer.parseInt(syncId), schema, session, cachedDataInserts, cachedDataUpdates, cachedDataDeletes);
+        updateSyncData(Integer.parseInt(syncId), schema, session, cachedDataInserts, cachedDataUpdates, cachedDataDeletes);
 
         syncSessionRepository.finishSync(syncId, schema);
     }
@@ -272,7 +272,7 @@ public class SyncService {
         return new CommitSyncSession(tableName, subscriberId);
     }
 
-    private void UpdateSyncData(
+    private void updateSyncData(
             Integer syncId,
             String schema,
             CommitSyncSession session,

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -72,13 +72,13 @@ public class SyncService {
                 tableSchema = reader.getString("tableschema");
                 String tableFilter = reader.getString("tablefilter");
                 changes = enumerateChanges(reader.getString("tableid"), subscriberId, reader.getString("tablename"), tableSchema, tableFilter, subscriberUUID);
-                if (changes.pullChangeSet.HasRows)
-                    dataToSync.add(changes.tableSync);
+                if (changes.pullChangeSet().HasRows)
+                    dataToSync.add(changes.tableSync());
 
             } else
                 Logs.write(Logs.Level.INFO, "DoSync(). Table " + schema + "." + tableName + " was not found in MergeTablesToSync.");
 
-            PullChangeSet changeSet = changes != null ? changes.pullChangeSet : null;
+            PullChangeSet changeSet = changes != null ? changes.pullChangeSet() : null;
 
             Integer syncId = StartNewSync(
                     subscriberId,

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -177,37 +177,37 @@ public class SyncService {
         tableSync.TriggerDeleteDrop = "drop trigger if exists \"trmergedelete_" + tableName + "\"";
     }
 
-    private PullFilter buildPullFilter(String tableSchema, String tableName, String tableFilter, String subscriberUUID, String subscriberId) {
-        PullFilter pullFilter = new PullFilter();
+    private record PullFilter(String view, String changeDetectionCondition) {
+    }
 
-        pullFilter.View = tableSchema + "." + tableName;
+    private PullFilter buildPullFilter(String tableSchema, String tableName, String tableFilter, String subscriberUUID, String subscriberId) {
+        String view = tableSchema + "." + tableName;
 
         if (tableSchema == null || tableSchema.isEmpty())
-            pullFilter.View = tableName;
+            view = tableName;
 
-        pullFilter.ChangeDetectionCondition = " ";
+        String changeDetectionCondition = " ";
 
         if (tableFilter != null && tableFilter.trim().length() > 0) {
-            pullFilter.View = tableFilter;
-            if (pullFilter.View.startsWith("public.fn_") || pullFilter.View.startsWith("fn_")) {
-                pullFilter.View = pullFilter.View.replace("@incomming_uniquename", subscriberUUID);
-                pullFilter.ChangeDetectionCondition = " ";
+            view = tableFilter;
+
+            if (view.startsWith("public.fn_") || view.startsWith("fn_")) {
+                view = view.replace("@incomming_uniquename", subscriberUUID);
+                changeDetectionCondition = " ";
             } else {
-                pullFilter.ChangeDetectionCondition = "and vw.uniquename='" + subscriberUUID + "' ";
+                changeDetectionCondition = "and vw.uniquename='" + subscriberUUID + "' ";
             }
 
             if (tableName.equalsIgnoreCase("mergeidentity"))
-                pullFilter.ChangeDetectionCondition += " and tb.SubscriberId= " + subscriberId + " ";
+                changeDetectionCondition += " and tb.SubscriberId= " + subscriberId + " ";
 
             Logs.write(Logs.Level.TRACE, "Using filter [" + tableFilter + "] for table " + tableName);
         }
 
-        return pullFilter;
+        return new PullFilter(view, changeDetectionCondition);
     }
 
-    private static class EnumeratedTableChanges {
-        private DataObject tableSync;
-        private PullChangeSet pullChangeSet;
+    private record EnumeratedTableChanges(DataObject tableSync, PullChangeSet pullChangeSet) {
     }
 
     private EnumeratedTableChanges enumerateChanges(String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
@@ -219,9 +219,9 @@ public class SyncService {
 
         PullFilter pullFilter = buildPullFilter(tableSchema, tableName, tableFilter, subscriberUUID, subscriberId);
 
-        StringBuilder queryInserts = pullQueryBuilder.buildInsertChangesQuery(subscriberId, tableSchema, tableName, pullFilter.View, pullFilter.ChangeDetectionCondition, subscriberUUID);
-        StringBuilder queryUpdates = pullQueryBuilder.buildUpdateChangesQuery(subscriberId, tableSchema, tableName, pullFilter.View, pullFilter.ChangeDetectionCondition);
-        StringBuilder queryDeletes = pullQueryBuilder.buildDeleteChangesQuery(subscriberId, tableSchema, tableName, pullFilter.View, pullFilter.ChangeDetectionCondition, subscriberUUID);
+        StringBuilder queryInserts = pullQueryBuilder.buildInsertChangesQuery(subscriberId, tableSchema, tableName, pullFilter.view(), pullFilter.changeDetectionCondition(), subscriberUUID);
+        StringBuilder queryUpdates = pullQueryBuilder.buildUpdateChangesQuery(subscriberId, tableSchema, tableName, pullFilter.view(), pullFilter.changeDetectionCondition());
+        StringBuilder queryDeletes = pullQueryBuilder.buildDeleteChangesQuery(subscriberId, tableSchema, tableName, pullFilter.view(), pullFilter.changeDetectionCondition(), subscriberUUID);
 
         addSyncTriggers(tableSync, tableName, tableSchema);
 
@@ -230,10 +230,8 @@ public class SyncService {
         tableSync.RowsCount = changeSet.RowsCount.toString();
         tableSync.Records = changeSet.Records;
 
-        EnumeratedTableChanges changes = new EnumeratedTableChanges();
-        changes.tableSync = tableSync;
-        changes.pullChangeSet = changeSet;
-        return changes;
+        return new EnumeratedTableChanges(tableSync, changeSet);
+
     }
 
     public void CommitSync(String syncId, String schema) {
@@ -334,27 +332,26 @@ public class SyncService {
         }
     }
 
-        private void updateDeletedSyncData(String schema, CommitSyncSession session, CachedRowSet cachedDataDeletes) {
-            if (cachedDataDeletes != null) {
-                Connection cn = Database.getInstance().GetDBConnection();
-                try {
-                    PreparedStatement cmdD = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_DELETE(schema, session.tableName()));
-                    cachedDataDeletes.beforeFirst();
-                    while (cachedDataDeletes.next()) {
-                        cmdD.setString(1, cachedDataDeletes.getString(1));
-                        cmdD.setInt(2, session.subscriberId());
-                        cmdD.addBatch();
-                    }
-                    cmdD.executeBatch();
-
-                } catch (Exception e) {
-                    Logs.write(Logs.Level.ERROR, "UpdateSyncData()->deletes " + e.getMessage());
-                } finally {
-                    JDBCCloser.close(cn);
+    private void updateDeletedSyncData(String schema, CommitSyncSession session, CachedRowSet cachedDataDeletes) {
+        if (cachedDataDeletes != null) {
+            Connection cn = Database.getInstance().GetDBConnection();
+            try {
+                PreparedStatement cmdD = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_DELETE(schema, session.tableName()));
+                cachedDataDeletes.beforeFirst();
+                while (cachedDataDeletes.next()) {
+                    cmdD.setString(1, cachedDataDeletes.getString(1));
+                    cmdD.setInt(2, session.subscriberId());
+                    cmdD.addBatch();
                 }
-            }
+                cmdD.executeBatch();
 
+            } catch (Exception e) {
+                Logs.write(Logs.Level.ERROR, "UpdateSyncData()->deletes " + e.getMessage());
+            } finally {
+                JDBCCloser.close(cn);
+            }
         }
+    }
 
     public void ReceiveData(ObjectNode receivedData, String schema, String subscriberUUID, String deviceUniqueId) {
         Logs.write(Logs.Level.INFO, "Receiving data from subscriber " + subscriberUUID);

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -274,15 +274,15 @@ public class SyncService {
         return new CommitSyncSession(tableName, subscriberId);
     }
 
-    private void UpdateSyncData(Integer syncId, String schema, String tableName, Integer subscriberId, CachedRowSet cachedDataInserts, CachedRowSet cachedDataUpdates, CachedRowSet cachedDataDeletes) {
+    private void UpdateSyncData(Integer syncId, String schema, CommitSyncSession session, CachedRowSet cachedDataInserts, CachedRowSet cachedDataUpdates, CachedRowSet cachedDataDeletes) {
 
         if (cachedDataInserts != null) {
             Connection cn = Database.getInstance().GetDBConnection();
             try {
-                PreparedStatement cmdI = cn.prepareStatement(QUERIES.INSERT_MERGE_CONTENT(schema, tableName));
+                PreparedStatement cmdI = cn.prepareStatement(QUERIES.INSERT_MERGE_CONTENT(schema, session.tableName));
                 cachedDataInserts.beforeFirst();
                 while (cachedDataInserts.next()) {
-                    cmdI.setInt(1, subscriberId);
+                    cmdI.setInt(1, session.subscriberId);
                     cmdI.setString(2, cachedDataInserts.getString("rowid").trim());
                     cmdI.setTimestamp(3, new java.sql.Timestamp(new Date().getTime()));
                     cmdI.setInt(4, 1);
@@ -301,12 +301,12 @@ public class SyncService {
         if (cachedDataUpdates != null) {
             Connection cn = Database.getInstance().GetDBConnection();
             try {
-                PreparedStatement cmdU = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_UPDATE(schema, tableName));
+                PreparedStatement cmdU = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_UPDATE(schema, session.tableName));
 
                 cachedDataUpdates.beforeFirst();
                 while (cachedDataUpdates.next()) {
                     cmdU.setString(1, cachedDataUpdates.getString("rowid").trim());
-                    cmdU.setInt(2, subscriberId);
+                    cmdU.setInt(2, session.subscriberId);
                     cmdU.addBatch();
                 }
                 cmdU.executeBatch();
@@ -321,11 +321,11 @@ public class SyncService {
         if (cachedDataDeletes != null) {
             Connection cn = Database.getInstance().GetDBConnection();
             try {
-                PreparedStatement cmdD = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_DELETE(schema, tableName));
+                PreparedStatement cmdD = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_DELETE(schema, session.tableName));
                 cachedDataDeletes.beforeFirst();
                 while (cachedDataDeletes.next()) {
                     cmdD.setString(1, cachedDataDeletes.getString(1));
-                    cmdD.setInt(2, subscriberId);
+                    cmdD.setInt(2, session.subscriberId);
                     cmdD.addBatch();
                 }
                 cmdD.executeBatch();

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -274,15 +274,27 @@ public class SyncService {
         return new CommitSyncSession(tableName, subscriberId);
     }
 
-    private void UpdateSyncData(Integer syncId, String schema, CommitSyncSession session, CachedRowSet cachedDataInserts, CachedRowSet cachedDataUpdates, CachedRowSet cachedDataDeletes) {
+    private void UpdateSyncData(
+            Integer syncId,
+            String schema,
+            CommitSyncSession session,
+            CachedRowSet cachedDataInserts,
+            CachedRowSet cachedDataUpdates,
+            CachedRowSet cachedDataDeletes
+    ) {
+        updateInsertedSyncData(syncId, schema, session, cachedDataInserts);
+        updateUpdatedSyncData(schema, session, cachedDataUpdates);
+        updateDeletedSyncData(schema, session, cachedDataDeletes);
+    }
 
+    private void updateInsertedSyncData(Integer syncId, String schema, CommitSyncSession session, CachedRowSet cachedDataInserts) {
         if (cachedDataInserts != null) {
             Connection cn = Database.getInstance().GetDBConnection();
             try {
-                PreparedStatement cmdI = cn.prepareStatement(QUERIES.INSERT_MERGE_CONTENT(schema, session.tableName));
+                PreparedStatement cmdI = cn.prepareStatement(QUERIES.INSERT_MERGE_CONTENT(schema, session.tableName()));
                 cachedDataInserts.beforeFirst();
                 while (cachedDataInserts.next()) {
-                    cmdI.setInt(1, session.subscriberId);
+                    cmdI.setInt(1, session.subscriberId());
                     cmdI.setString(2, cachedDataInserts.getString("rowid").trim());
                     cmdI.setTimestamp(3, new java.sql.Timestamp(new Date().getTime()));
                     cmdI.setInt(4, 1);
@@ -298,15 +310,18 @@ public class SyncService {
             }
         }
 
+    }
+
+    private void updateUpdatedSyncData(String schema, CommitSyncSession session, CachedRowSet cachedDataUpdates) {
         if (cachedDataUpdates != null) {
             Connection cn = Database.getInstance().GetDBConnection();
             try {
-                PreparedStatement cmdU = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_UPDATE(schema, session.tableName));
+                PreparedStatement cmdU = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_UPDATE(schema, session.tableName()));
 
                 cachedDataUpdates.beforeFirst();
                 while (cachedDataUpdates.next()) {
                     cmdU.setString(1, cachedDataUpdates.getString("rowid").trim());
-                    cmdU.setInt(2, session.subscriberId);
+                    cmdU.setInt(2, session.subscriberId());
                     cmdU.addBatch();
                 }
                 cmdU.executeBatch();
@@ -317,26 +332,29 @@ public class SyncService {
                 JDBCCloser.close(cn);
             }
         }
-
-        if (cachedDataDeletes != null) {
-            Connection cn = Database.getInstance().GetDBConnection();
-            try {
-                PreparedStatement cmdD = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_DELETE(schema, session.tableName));
-                cachedDataDeletes.beforeFirst();
-                while (cachedDataDeletes.next()) {
-                    cmdD.setString(1, cachedDataDeletes.getString(1));
-                    cmdD.setInt(2, session.subscriberId);
-                    cmdD.addBatch();
-                }
-                cmdD.executeBatch();
-
-            } catch (Exception e) {
-                Logs.write(Logs.Level.ERROR, "UpdateSyncData()->deletes " + e.getMessage());
-            } finally {
-                JDBCCloser.close(cn);
-            }
-        }
     }
+
+        private void updateDeletedSyncData(String schema, CommitSyncSession session, CachedRowSet cachedDataDeletes) {
+            if (cachedDataDeletes != null) {
+                Connection cn = Database.getInstance().GetDBConnection();
+                try {
+                    PreparedStatement cmdD = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_DELETE(schema, session.tableName()));
+                    cachedDataDeletes.beforeFirst();
+                    while (cachedDataDeletes.next()) {
+                        cmdD.setString(1, cachedDataDeletes.getString(1));
+                        cmdD.setInt(2, session.subscriberId());
+                        cmdD.addBatch();
+                    }
+                    cmdD.executeBatch();
+
+                } catch (Exception e) {
+                    Logs.write(Logs.Level.ERROR, "UpdateSyncData()->deletes " + e.getMessage());
+                } finally {
+                    JDBCCloser.close(cn);
+                }
+            }
+
+        }
 
     public void ReceiveData(ObjectNode receivedData, String schema, String subscriberUUID, String deviceUniqueId) {
         Logs.write(Logs.Level.INFO, "Receiving data from subscriber " + subscriberUUID);

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -241,13 +241,26 @@ public class SyncService {
         CachedRowSet cachedDataUpdates = syncSessionStore.readUpdates(syncId);
         CachedRowSet cachedDataDeletes = syncSessionStore.readDeletes(syncId);
 
+        CommitSyncSession session = readCommitSyncSession(syncId, schema);
+
+        UpdateSyncData(Integer.parseInt(syncId), schema, session, cachedDataInserts, cachedDataUpdates, cachedDataDeletes);
+
+        syncSessionRepository.finishSync(syncId, schema);
+    }
+
+    private record CommitSyncSession(String tableName, int subscriberId) {
+    }
+
+    private CommitSyncSession readCommitSyncSession(String syncId, String schema) {
         String tableName = "";
         int subscriberId = 0;
+
         Connection cn = Database.getInstance().GetDBConnection();
         try {
             PreparedStatement query = cn.prepareStatement(QUERIES.COMMIT_SYNC(schema));
             query.setInt(1, Integer.parseInt(syncId));
             ResultSet reader = query.executeQuery();
+
             while (reader.next()) {
                 tableName = reader.getString("TableName");
                 subscriberId = reader.getInt("subscriberId");
@@ -258,9 +271,9 @@ public class SyncService {
             JDBCCloser.close(cn);
         }
 
-        UpdateSyncData(Integer.parseInt(syncId), schema, tableName, subscriberId, cachedDataInserts, cachedDataUpdates, cachedDataDeletes);
-        syncSessionRepository.finishSync(syncId, schema);
+        return new CommitSyncSession(tableName, subscriberId);
     }
+
     private void UpdateSyncData(Integer syncId, String schema, String tableName, Integer subscriberId, CachedRowSet cachedDataInserts, CachedRowSet cachedDataUpdates, CachedRowSet cachedDataDeletes) {
 
         if (cachedDataInserts != null) {


### PR DESCRIPTION
## Summary

Refactors the commit-sync flow to make it easier to read, and cleans up small helper objects used by the sync-compressed flow.


## Changes

- Extracted commit-sync session lookup into `readCommitSyncSession()`.
- Added `CommitSyncSession` to group the table name and subscriber id used
during commit-sync.
- Split `updateSyncData()` into separate insert, update, and delete helper methods.
- Changed `EnumeratedTableChanges` from a mutable helper class to a local record.
- Changed `PullFilter` from a separate mutable class to a local record
- No business logic changes.


## Testing

- Regression sync tests pass locally.
