### PR TITLE
Refactor/08 receive changes record writes

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -481,17 +481,7 @@ public class SyncService {
 
             if (inserts.isArray()) {
                 for (JsonNode node : inserts) {
-                    Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
-                    while (fields.hasNext()) {
-                        Map.Entry<String, JsonNode> entry = fields.next();
-                        String fieldName = entry.getKey();
-                        JsonNode value = entry.getValue();
-                        if (!fieldName.equalsIgnoreCase(SQLQueries.GET_ROWID_COLUMN_NAME())) {
-                            DatabaseTableParameter param = getParamForDbField(fieldName, paramList);
-                            if (param != null)
-                                ParseStatementParameter(insertStatement, param.ParameterOrder, fieldName, value.asText(), param);
-                        }
-                    }
+                    bindJsonFieldsToStatement(node, insertStatement, paramList, true);
                     try {
                         String rowIdValue = UUID.randomUUID().toString();
                         DatabaseTableParameter param = getParamForDbField(SQLQueries.GET_ROWID_COLUMN_NAME(), paramList);
@@ -526,15 +516,7 @@ public class SyncService {
             PreparedStatement updateStatement = cn.prepareStatement(updateSQLQuery);
             if (updates.isArray()) {
                 for (JsonNode node : updates) {
-                    Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
-                    while (fields.hasNext()) {
-                        Map.Entry<String, JsonNode> entry = fields.next();
-                        String fieldName = entry.getKey();
-                        JsonNode value = entry.getValue();
-                        DatabaseTableParameter param = getParamForDbField(fieldName, paramList);
-                        if (param != null)
-                            ParseStatementParameter(updateStatement, param.ParameterOrder, fieldName, value.asText(), param);
-                    }
+                    bindJsonFieldsToStatement(node, updateStatement, paramList, false);
                     updateStatement.addBatch();
                 }
 
@@ -546,6 +528,29 @@ public class SyncService {
             Logs.write(Logs.Level.ERROR, "PushUpdateRecords() " + currentTable + "," + e.getMessage());
         } finally {
             JDBCCloser.close(cn);
+        }
+    }
+
+
+    private void bindJsonFieldsToStatement(
+            JsonNode node,
+            PreparedStatement statement,
+            List<DatabaseTableParameter> paramList,
+            boolean skipRowId
+    ) {
+        Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> entry = fields.next();
+            String fieldName = entry.getKey();
+            JsonNode value = entry.getValue();
+
+            if (!skipRowId || !fieldName.equalsIgnoreCase(SQLQueries.GET_ROWID_COLUMN_NAME())) {
+                DatabaseTableParameter param = getParamForDbField(fieldName, paramList);
+                if (param != null)
+                    ParseStatementParameter(statement, param.ParameterOrder,
+                            fieldName, value.asText(), param);
+            }
         }
     }
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -481,29 +481,43 @@ public class SyncService {
 
             if (inserts.isArray()) {
                 for (JsonNode node : inserts) {
-                    bindJsonFieldsToStatement(node, insertStatement, paramList, true);
-                    try {
-                        String rowIdValue = UUID.randomUUID().toString();
-                        DatabaseTableParameter param = getParamForDbField(SQLQueries.GET_ROWID_COLUMN_NAME(), paramList);
-                        insertStatement.setString(param.ParameterOrder, rowIdValue);
-                        insertStatement.execute();
-
-                        mergeContent.setInt(1, Integer.parseInt(subscriber));
-                        mergeContent.setString(2, rowIdValue);
-                        mergeContent.setTimestamp(3, new java.sql.Timestamp(new Date().getTime()));
-                        mergeContent.setInt(4, 1);//action
-                        mergeContent.setInt(5, 0);//syncId
-                        mergeContent.setBoolean(6, true);//record_has_changed
-                        mergeContent.execute();
-                    } catch (SQLException e) {
-                        Logs.write(Logs.Level.ERROR, "PushInsertRecords()->Execute insert: " + e.getMessage() + "; " + insertStatement);
-                    }
+                    pushInsertRecord(node, subscriber, insertStatement, mergeContent,
+                            paramList);
                 }
             }
         } catch (SQLException e) {
             Logs.write(Logs.Level.ERROR, "PushInsertRecords() " + e.getMessage());
         } finally {
             JDBCCloser.close(cn);
+        }
+    }
+
+    private void pushInsertRecord(
+            JsonNode node,
+            String subscriber,
+            PreparedStatement insertStatement,
+            PreparedStatement mergeContent,
+            List<DatabaseTableParameter> paramList
+    ) {
+        bindJsonFieldsToStatement(node, insertStatement, paramList, true);
+
+        try {
+            String rowIdValue = UUID.randomUUID().toString();
+            DatabaseTableParameter param =
+                    getParamForDbField(SQLQueries.GET_ROWID_COLUMN_NAME(), paramList);
+            insertStatement.setString(param.ParameterOrder, rowIdValue);
+            insertStatement.execute();
+
+            mergeContent.setInt(1, Integer.parseInt(subscriber));
+            mergeContent.setString(2, rowIdValue);
+            mergeContent.setTimestamp(3, new java.sql.Timestamp(new Date().getTime()));
+            mergeContent.setInt(4, 1);
+            mergeContent.setInt(5, 0);
+            mergeContent.setBoolean(6, true);
+            mergeContent.execute();
+        } catch (SQLException e) {
+            Logs.write(Logs.Level.ERROR, "PushInsertRecords()->Execute insert: " +
+                    e.getMessage() + "; " + insertStatement);
         }
     }
 
@@ -559,21 +573,26 @@ public class SyncService {
         try {
             if (deletes.isArray()) {
                 for (JsonNode node : deletes) {
-                    String rowid = node.path("rowid").asText();
-                    String tableId = node.path("table").asText();
-                    String deleteQuery = "delete from " + schema + "." + tableId + " where rowid='" + rowid + "'";
-                    try {
-                        Statement deleteStatment = cn.createStatement();
-                        deleteStatment.executeUpdate(deleteQuery);
-                    } catch (SQLException e) {
-                        Logs.write(Logs.Level.ERROR, "PushDeletedRecords() " + e.getMessage());
-                    }
+                    pushDeletedRecord(cn, node, schema);
                 }
             }
         } catch (Exception e) {
             Logs.write(Logs.Level.ERROR, "PushDeletedRecords() " + e.getMessage());
         } finally {
             JDBCCloser.close(cn);
+        }
+    }
+
+    private void pushDeletedRecord(Connection cn, JsonNode node, String schema) {
+        String rowid = node.path("rowid").asText();
+        String tableId = node.path("table").asText();
+        String deleteQuery = "delete from " + schema + "." + tableId + " where rowid='" + rowid + "'";
+
+        try {
+            Statement deleteStatement = cn.createStatement();
+            deleteStatement.executeUpdate(deleteQuery);
+        } catch (SQLException e) {
+            Logs.write(Logs.Level.ERROR, "PushDeletedRecords() " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary

Refactors record writing in the receive-changes flow.

PR extracts repeated JSON field binding and separates single-record insert/delete handling from the higher level
insert/update/delete loops.

## Changes

- Extracted JSON field binding into `bindJsonFieldsToStatement()`.
- using this field binding for both insert and update records.
- Kept the existing insert behavior where `rowid` from the payload is skipped and a new backend rowid is generated.
- Extracted single insert handling into `pushInsertRecord()`.
- Extracted single delete handling into `pushDeletedRecord()`.
- Kept the existing delete SQL behavior unchanged.
-  No  business logic changes.

## Testing

- Regression sync tests pass locally.
