### PR TITLE
Refactor/10 prepopulate flow

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
@@ -200,13 +200,7 @@ public class SQLitePrepopulate {
 
             DatabaseTable table = DatabaseTableGuavaCacheUtil.getTableUsingGuava(tableName, tableSchema);
 
-            Statement trDelete = connSqliteLocal.createStatement();
-            if (!tableName.equalsIgnoreCase("mergeidentity")) {
-                trDelete.addBatch("drop trigger if exists \"trMergeInsert_" + tableName + "\"");
-                trDelete.addBatch("drop trigger if exists \"trMergeUpdate_" + tableName + "\"");
-                trDelete.addBatch("drop trigger if exists \"trMergeDelete_" + tableName + "\"");
-                trDelete.executeBatch();
-            }
+            dropPrepopulateTriggers(tableName);
 
             String queryInsert = buildPrepopulateInsertQuery(table, tableName);
 
@@ -287,18 +281,8 @@ public class SQLitePrepopulate {
                 insert.executeBatch();
             }
 
-            Statement trCreate = connSqliteLocal.createStatement();
-            if (!tableName.equalsIgnoreCase("MergeIdentity")) {
-                String q = schemaGenerator.CreateUpdateTrigger(table, schemaGenerator.GenerateUpdateableColumns(table.Columns));
-                if(q.trim().length() > 0)
-                    trCreate.addBatch(q);
+            createPrepopulateTriggers(schemaGenerator, table, tableName);
 
-                q = schemaGenerator.CreateDeleteTrigger(table);
-                if(q.trim().length() > 0)
-                    trCreate.addBatch(q);
-
-                trCreate.executeBatch();
-            }
             Integer syncId = syncService.StartNewSync(
                     subscriberId,
                     Integer.parseInt(tableId),
@@ -316,6 +300,30 @@ public class SQLitePrepopulate {
             if(tablesData.size() > 0 && tablesData.size() == 5000 && tablePackageCount < 13) {
                 EnumerateChanges(tableId, subscriberId, tableName, tableSchema, tableFilter, subscriberUUID);
             }
+        }
+    }
+
+    private void dropPrepopulateTriggers(String tableName) throws SQLException {
+        Statement trDelete = connSqliteLocal.createStatement();
+        if (!tableName.equalsIgnoreCase("mergeidentity")) {
+            trDelete.addBatch("drop trigger if exists \"trMergeInsert_" + tableName + "\"");
+            trDelete.addBatch("drop trigger if exists \"trMergeUpdate_" + tableName + "\"");
+            trDelete.addBatch("drop trigger if exists \"trMergeDelete_" + tableName + "\"");
+            trDelete.executeBatch();
+        }
+    }
+    private void createPrepopulateTriggers(SchemaGenerator schemaGenerator, DatabaseTable table, String tableName) throws SQLException {
+        Statement trCreate = connSqliteLocal.createStatement();
+        if (!tableName.equalsIgnoreCase("MergeIdentity")) {
+            String q = schemaGenerator.CreateUpdateTrigger(table, schemaGenerator.GenerateUpdateableColumns(table.Columns));
+            if(q.trim().length() > 0)
+                trCreate.addBatch(q);
+
+            q = schemaGenerator.CreateDeleteTrigger(table);
+            if(q.trim().length() > 0)
+                trCreate.addBatch(q);
+
+            trCreate.executeBatch();
         }
     }
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
@@ -169,29 +169,28 @@ public class SQLitePrepopulate {
         }
     }
 
+    private record PrepopulateFilter(String view, String changeDetectionCondition) {
+    }
+
     private void EnumerateChanges(String tableId, String subscriberId, String tableName, String tableSchema, String tableFilter, String subscriberUUID) {
         SyncService syncService = new SyncService();
 
-        String filterVW = tableSchema + "." + tableName;
-        if (tableSchema == null || tableSchema.isEmpty())
-            filterVW = tableName;
+        PrepopulateFilter filter = buildPrepopulateFilter(
+                tableSchema,
+                tableName,
+                tableFilter,
+                subscriberUUID,
+                subscriberId
+        );
 
-        String filterVW_CD = " ";
-
-        if (tableFilter != null && tableFilter.trim().length() > 0) {
-            filterVW = tableFilter;
-            if(filterVW.startsWith("public.fn_") || filterVW.startsWith("fn_")) {
-                filterVW = filterVW.replace("@incomming_uniquename", subscriberUUID);
-                filterVW_CD = " ";
-            }
-            else
-                filterVW_CD = "and vw.uniquename='" + subscriberUUID + "' ";
-            if(tableName.equalsIgnoreCase("mergeidentity"))
-                filterVW_CD += " and vw.SubscriberId= " + subscriberId + " ";
-            Logs.write(Logs.Level.TRACE, "Using filter [" + tableFilter + "] for table " + tableName);
-        }
-
-        StringBuilder query = BuildMergeQuery(tableId, subscriberId, tableName, tableSchema, filterVW, filterVW_CD);
+        StringBuilder query = BuildMergeQuery(
+                tableId,
+                subscriberId,
+                tableName,
+                tableSchema,
+                filter.view(),
+                filter.changeDetectionCondition()
+        );
 
         SchemaGenerator schemaGenerator = new SchemaGenerator();
 
@@ -336,6 +335,39 @@ public class SQLitePrepopulate {
                 EnumerateChanges(tableId, subscriberId, tableName, tableSchema, tableFilter, subscriberUUID);
             }
         }
+    }
+
+    private PrepopulateFilter buildPrepopulateFilter(
+            String tableSchema,
+            String tableName,
+            String tableFilter,
+            String subscriberUUID,
+            String subscriberId
+    ) {
+        String view = tableSchema + "." + tableName;
+
+        if (tableSchema == null || tableSchema.isEmpty())
+            view = tableName;
+
+        String changeDetectionCondition = " ";
+
+        if (tableFilter != null && tableFilter.trim().length() > 0) {
+            view = tableFilter;
+
+            if (view.startsWith("public.fn_") || view.startsWith("fn_")) {
+                view = view.replace("@incomming_uniquename", subscriberUUID);
+                changeDetectionCondition = " ";
+            } else {
+                changeDetectionCondition = "and vw.uniquename='" + subscriberUUID + "' ";
+            }
+
+            if (tableName.equalsIgnoreCase("mergeidentity"))
+                changeDetectionCondition += " and vw.SubscriberId= " + subscriberId + " ";
+
+            Logs.write(Logs.Level.TRACE, "Using filter [" + tableFilter + "] for table " + tableName);
+        }
+
+        return new PrepopulateFilter(view, changeDetectionCondition);
     }
 
     public StringBuilder BuildMergeQuery(String tableId, String subscriberId, String tableName, String tableSchema, String filterVW, String filterVW_CD) {

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
@@ -208,25 +208,7 @@ public class SQLitePrepopulate {
                 trDelete.executeBatch();
             }
 
-            String queryInsert = "";
-            StringBuilder insertStatment = new StringBuilder();
-
-            insertStatment.append("insert or ignore into " + tableName + " (");
-            for (DatabaseTableColumn col : table.Columns)
-                if (!col.Name.equalsIgnoreCase("mergeinsertsource")) {
-                    insertStatment.append("[" + col.Name + "]");
-                    insertStatment.append(",");
-                }
-
-            queryInsert = insertStatment.toString().substring(0, insertStatment.toString().length() - 1) + ") values (";
-            insertStatment = new StringBuilder();
-            for (DatabaseTableColumn col : table.Columns)
-                if (!col.Name.equalsIgnoreCase("mergeinsertsource")) {
-                    insertStatment.append("?");
-                    insertStatment.append(",");
-                }
-
-            queryInsert += insertStatment.toString().substring(0, insertStatment.toString().length() - 1) + ");";
+            String queryInsert = buildPrepopulateInsertQuery(table, tableName);
 
             PreparedStatement insert = connSqliteLocal.prepareStatement(queryInsert);
             Integer batchCount = 0;
@@ -368,6 +350,29 @@ public class SQLitePrepopulate {
         }
 
         return new PrepopulateFilter(view, changeDetectionCondition);
+    }
+
+    private String buildPrepopulateInsertQuery(DatabaseTable table, String tableName) {
+        StringBuilder columns = new StringBuilder();
+
+        columns.append("insert or ignore into " + tableName + " (");
+        for (DatabaseTableColumn col : table.Columns)
+            if (!col.Name.equalsIgnoreCase("mergeinsertsource")) {
+                columns.append("[" + col.Name + "]");
+                columns.append(",");
+            }
+
+        String queryInsert = columns.toString().substring(0, columns.toString().length() - 1) + ") values (";
+
+        StringBuilder values = new StringBuilder();
+        for (DatabaseTableColumn col : table.Columns)
+            if (!col.Name.equalsIgnoreCase("mergeinsertsource")) {
+                values.append("?");
+                values.append(",");
+            }
+
+        queryInsert += values.toString().substring(0, values.toString().length() - 1) + ");";
+        return queryInsert;
     }
 
     public StringBuilder BuildMergeQuery(String tableId, String subscriberId, String tableName, String tableSchema, String filterVW, String filterVW_CD) {


### PR DESCRIPTION
## Summary

first part (out of 3) of the prepopulate flow by extracting setup logic from `SQLitePrepopulate`.

## Changes

- Extracted prepopulate filter creation into a separate helper.
- Extracted SQLite insert query construction.
- Extracted sync trigger setup for prepopulated tables.
- No business logic changes.

## Testing

- Regression sync tests pass locally.


