### PR TITLE
Refactor/13 sync flow cleanup

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
@@ -18,7 +18,7 @@ import java.sql.Statement;
 final class PullChangeEnumerator {
     private final SyncRecordMapper recordMapper = new SyncRecordMapper();
 
-    public PullChangeSet enumerate(StringBuilder queryInserts, StringBuilder queryUpdates, StringBuilder queryDeletes) {
+    PullChangeSet enumerate(StringBuilder queryInserts, StringBuilder queryUpdates, StringBuilder queryDeletes) {
         PullChangeSet changeSet = new PullChangeSet();
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode root = mapper.createObjectNode();

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullChangeEnumerator.java
@@ -15,7 +15,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-public class PullChangeEnumerator {
+final class PullChangeEnumerator {
     private final SyncRecordMapper recordMapper = new SyncRecordMapper();
 
     public PullChangeSet enumerate(StringBuilder queryInserts, StringBuilder queryUpdates, StringBuilder queryDeletes) {

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullQueryBuilder.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullQueryBuilder.java
@@ -14,19 +14,19 @@ final class PullQueryBuilder {
         query.append("from " + tableSchema + "." + tableName + " tb ");
         query.append("join (");
         query.append("select vw.rowid ");
-        if(filterVW_CD.trim().length() > 0 || filterVW.startsWith("public.fn_") || filterVW.startsWith("fn_")) {
+        if (filterVW_CD.trim().length() > 0 || filterVW.startsWith("public.fn_") || filterVW.startsWith("fn_")) {
             query.append("from " + tableSchema + "." + filterVW + " vw ");
         } else {
             query.append("from " + tableSchema + "." + tableName + " vw ");
         }
         query.append("where ");
         query.append("not exists (select 1 from  " + tableSchema + ".MergeContent_" + tableName + " t where vw.rowid=t.rowid and t.SubscriberId=" + subscriberId + ") ");
-        if(!filterVW.startsWith(tableSchema + ".fn_") && !filterVW.startsWith("fn_"))
-            if(filterVW_CD.trim().length() > 0)
+        if (!filterVW.startsWith(tableSchema + ".fn_") && !filterVW.startsWith("fn_"))
+            if (filterVW_CD.trim().length() > 0)
                 query.append("and vw.uniquename='"+subscriberUUID+"'");
         query.append(" " + topLimit + "");
         query.append(") inserts on tb.rowid = inserts.rowid ");
-        if(tableName.equalsIgnoreCase("mergeidentity"))
+        if (tableName.equalsIgnoreCase("mergeidentity"))
             query.append("and tb.subscriberid =" + subscriberId);
 
         return query;
@@ -41,7 +41,7 @@ final class PullQueryBuilder {
         query.append("select distinct ");
         query.append("tb.*");
         query.append("from " + tableSchema + "." + tableName + " tb ");
-        if(filterVW_CD.trim().length() > 0 || filterVW.startsWith("public.fn_") || filterVW.startsWith("fn_")) {
+        if (filterVW_CD.trim().length() > 0 || filterVW.startsWith("public.fn_") || filterVW.startsWith("fn_")) {
             query.append("join " + tableSchema + "." + filterVW + " vw on tb.rowid=vw.rowid ");
             query.append("join " + tableSchema + ".mergecontent_" + tableName + " t on vw.rowid=t.rowid ");
         } else {
@@ -49,7 +49,7 @@ final class PullQueryBuilder {
         }
 
         query.append("where t.record_has_changed=true and t.SubscriberId=" + subscriberId + " " + filterVW_CD + " ");
-        if(tableName.equalsIgnoreCase("mergeidentity"))
+        if (tableName.equalsIgnoreCase("mergeidentity"))
             query.append(" and tb.subscriberid =" + subscriberId);
         query.append(" " + topLimit + ";");
 
@@ -61,8 +61,8 @@ final class PullQueryBuilder {
         query.append("select  ");
         query.append("m.rowid ");
         query.append("from " + tableSchema + ".mergecontent_" + tableName + " m ");
-        if(filterVW_CD.trim().length() > 0 || filterVW.startsWith(tableSchema + ".fn_") || filterVW.startsWith("fn_")) {
-            if(tableName.equalsIgnoreCase("mergeidentity"))
+        if (filterVW_CD.trim().length() > 0 || filterVW.startsWith(tableSchema + ".fn_") || filterVW.startsWith("fn_")) {
+            if (tableName.equalsIgnoreCase("mergeidentity"))
                 query.append("left join " + tableSchema + "." + filterVW + " vw on m.rowid=vw.rowid and vw.uniquename='" + subscriberUUID + "' and vw.subscriberid =" + subscriberId + " ");
             else
                 query.append("left join " + tableSchema + "." + filterVW + " vw on m.rowid=vw.rowid " + filterVW_CD + " ");

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullQueryBuilder.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullQueryBuilder.java
@@ -3,7 +3,7 @@ package com.ampliapps.amplisync.SyncServer.Synchronization;
 import com.ampliapps.amplisync.SQLiteSyncConfig;
 
 final class PullQueryBuilder {
-    public StringBuilder buildInsertChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscriberUUID) {
+    StringBuilder buildInsertChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscriberUUID) {
         StringBuilder query = new StringBuilder();
         String topLimit = "";
         if (SQLiteSyncConfig.PACKAGE_SIZE != null && !SQLiteSyncConfig.PACKAGE_SIZE.isEmpty())
@@ -32,7 +32,7 @@ final class PullQueryBuilder {
         return query;
     }
 
-    public StringBuilder buildUpdateChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD) {
+    StringBuilder buildUpdateChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD) {
         StringBuilder query = new StringBuilder();
         String topLimit = "";
         if (SQLiteSyncConfig.PACKAGE_SIZE != null && !SQLiteSyncConfig.PACKAGE_SIZE.isEmpty())
@@ -56,7 +56,7 @@ final class PullQueryBuilder {
         return query;
     }
 
-    public StringBuilder buildDeleteChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscriberUUID) {
+    StringBuilder buildDeleteChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscriberUUID) {
         StringBuilder query = new StringBuilder();
         query.append("select  ");
         query.append("m.rowid ");

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullQueryBuilder.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/PullQueryBuilder.java
@@ -2,7 +2,7 @@ package com.ampliapps.amplisync.SyncServer.Synchronization;
 
 import com.ampliapps.amplisync.SQLiteSyncConfig;
 
-public class PullQueryBuilder {
+final class PullQueryBuilder {
     public StringBuilder buildInsertChangesQuery(String subscriberId, String tableSchema, String tableName, String filterVW, String filterVW_CD, String subscriberUUID) {
         StringBuilder query = new StringBuilder();
         String topLimit = "";

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLiteClientQueryBuilder.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLiteClientQueryBuilder.java
@@ -1,6 +1,6 @@
 package com.ampliapps.amplisync.SyncServer.Synchronization;
 
-public class SQLiteClientQueryBuilder {
+final class SQLiteClientQueryBuilder {
     public void buildQueries(DataObject tableSync, String tableSchema) {
         String tableNameClear = tableSync.TableName;
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLiteClientQueryBuilder.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLiteClientQueryBuilder.java
@@ -7,7 +7,7 @@ final class SQLiteClientQueryBuilder {
         DatabaseTable table = DatabaseTableGuavaCacheUtil.getTableUsingGuava(tableNameClear, tableSchema);
 
         StringBuilder insertStatement = new StringBuilder();
-        StringBuilder updateStatment = new StringBuilder();
+        StringBuilder updateStatement = new StringBuilder();
 
         insertStatement.append("insert or replace into " + tableNameClear + " (");
         for (DatabaseTableColumn col : table.Columns)
@@ -25,29 +25,29 @@ final class SQLiteClientQueryBuilder {
             }
         tableSync.QueryInsert += insertStatement.substring(0, insertStatement.toString().length() - 1) + ");";
 
-        updateStatment.append("update " + tableNameClear + " set ");
+        updateStatement.append("update " + tableNameClear + " set ");
         for (DatabaseTableColumn col : table.Columns)
             if (!col.Name.equalsIgnoreCase("mergeinsertsource")) {
                 if (!col.IsInPrimaryKey) {
-                    updateStatment.append("[" + col.Name + "]");
-                    updateStatment.append("=?,");
+                    updateStatement.append("[" + col.Name + "]");
+                    updateStatement.append("=?,");
                 }
             }
 
-        updateStatment = new StringBuilder(updateStatment.substring(0, updateStatment.toString().length() - 1));
+        updateStatement = new StringBuilder(updateStatement.substring(0, updateStatement.toString().length() - 1));
 
-        updateStatment.append(" where ");
+        updateStatement.append(" where ");
 
         if (table.PrimaryKeyColumns.size() > 0) {
             for (String pk : table.PrimaryKeyColumns) {
-                updateStatment.append(pk);
-                updateStatment.append("=? and ");
+                updateStatement.append(pk);
+                updateStatement.append("=? and ");
             }
 
-            tableSync.QueryUpdate = updateStatment.substring(0, updateStatment.toString().length() - 5) + ";";
+            tableSync.QueryUpdate = updateStatement.substring(0, updateStatement.toString().length() - 5) + ";";
         } else {
-            updateStatment.append(SQLQueries.GET_ROWID_COLUMN_NAME() + "=?");
-            tableSync.QueryUpdate = updateStatment + ";";
+            updateStatement.append(SQLQueries.GET_ROWID_COLUMN_NAME() + "=?");
+            tableSync.QueryUpdate = updateStatement + ";";
         }
 
         tableSync.QueryDelete = "delete from " + tableNameClear + " where " + SQLQueries.GET_ROWID_COLUMN_NAME() + "=";

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLiteClientQueryBuilder.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLiteClientQueryBuilder.java
@@ -1,7 +1,7 @@
 package com.ampliapps.amplisync.SyncServer.Synchronization;
 
 final class SQLiteClientQueryBuilder {
-    public void buildQueries(DataObject tableSync, String tableSchema) {
+    void buildQueries(DataObject tableSync, String tableSchema) {
         String tableNameClear = tableSync.TableName;
 
         DatabaseTable table = DatabaseTableGuavaCacheUtil.getTableUsingGuava(tableNameClear, tableSchema);

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SQLitePrepopulate.java
@@ -24,7 +24,7 @@ public class SQLitePrepopulate {
     private Connection connSqliteLocal = null;
     private Integer tablePackageCount = 1;
 
-    private Connection sQLiteConnection(String deviceUUID) {
+    private Connection sqliteConnection(String deviceUUID) {
 
         Connection conn = null;
         try {
@@ -39,7 +39,7 @@ public class SQLitePrepopulate {
 
     }
 
-    public String PrepopulateDatabase(String subscriberUUID, String deviceUUID){
+    public String PrepopulateDatabase(String subscriberUUID, String deviceUUID) {
         Logs.write(Logs.Level.INFO, "PrepopulateDatabase subscriberUUID " + subscriberUUID + ", deviceUUID " + deviceUUID);
         String path = SQLiteSyncConfig.WORKING_DIR + "sqlite-databases";
         String userSchema = UserSchemaGuavaCacheUtil.getUserSchemaUsingGuava(subscriberUUID);
@@ -55,12 +55,12 @@ public class SQLitePrepopulate {
         String dbSchema = schemaGenerator.GetFullSchematScript(subscriberUUID, deviceUUID);
         createEmptyDatabase(deviceUUID, dbSchema);
         Map<Integer, String> tablesList = commonTools.GetSynchronizedTables(userSchema);
-        for(Map.Entry<Integer, String> entry : tablesList.entrySet())
+        for (Map.Entry<Integer, String> entry : tablesList.entrySet())
             populateTable(subscriberUUID, entry.getValue(), deviceUUID);
 
         String dbFilePath = backupPrepopulateDatabase();
 
-        if(connSqliteLocal != null)
+        if (connSqliteLocal != null)
             JDBCCloser.close(connSqliteLocal);
 
         return zipPrepopulateDatabase(dbFilePath, commonTools);
@@ -124,21 +124,18 @@ public class SQLitePrepopulate {
             mapper = null;
         }
 
-        connSqliteLocal = sQLiteConnection(deviceUUID);
-        try
-        {
+        connSqliteLocal = sqliteConnection(deviceUUID);
+        try {
             Statement statement = connSqliteLocal.createStatement();
 
             SortedSet<String> keys = new TreeSet<>(schema.keySet());
             for (String key : keys) {
-                if(!key.startsWith("00000")) {
+                if (!key.startsWith("00000")) {
                     String value = schema.get(key);
                     statement.execute(value);
                 }
             }
-        }
-        catch(SQLException e)
-        {
+        } catch (SQLException e) {
             Logs.write(Logs.Level.ERROR, "CreateEmptyDatabase() " + e.getMessage());
         }
     }
@@ -159,7 +156,7 @@ public class SQLitePrepopulate {
             PrepopulateTableDefinition tableDefinition = findPrepopulateTable(cn, name, userSchema);
 
             if (tableDefinition != null) {
-                Logs.write(Logs.Level.INFO, "PrepopulateDatabase->table "+ subscriberUUID +"/" + tableDefinition.tableName());
+                Logs.write(Logs.Level.INFO, "PrepopulateDatabase->table " + subscriberUUID + "/" + tableDefinition.tableName());
                 tablePackageCount = 1;
                 enumerateChanges(
                         tableDefinition.tableId(),
@@ -280,7 +277,7 @@ public class SQLitePrepopulate {
                         }
 
                     } catch (Exception e) {
-                        Logs.write(Logs.Level.ERROR, "EnumerateChanges()->record iterate: "+ tableName+". " + e.getMessage());
+                        Logs.write(Logs.Level.ERROR, "EnumerateChanges()->record iterate: " + tableName + ". " + e.getMessage());
                     }
                 }
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncRecordMapper.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncRecordMapper.java
@@ -13,7 +13,7 @@ import java.util.Date;
 
 final class SyncRecordMapper {
 
-    public void writeColumn(ObjectNode record, String columnName, String colDataType, String colValue, Boolean wasNull) {
+    void writeColumn(ObjectNode record, String columnName, String colDataType, String colValue, Boolean wasNull) {
         record.put(columnName, 1);
         if (colDataType.equalsIgnoreCase("Boolean") || colDataType.equalsIgnoreCase("bool") || colDataType.equalsIgnoreCase("bit")) {
             if (colValue == null || colValue.isEmpty() || colValue.equalsIgnoreCase("False"))

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncRecordMapper.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncRecordMapper.java
@@ -11,7 +11,7 @@ import java.text.SimpleDateFormat;
 import java.util.Base64;
 import java.util.Date;
 
-public class SyncRecordMapper {
+final class SyncRecordMapper {
 
     public void writeColumn(ObjectNode record, String columnName, String colDataType, String colValue, Boolean wasNull) {
         record.put(columnName, 1);

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncRecordMapper.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncRecordMapper.java
@@ -29,7 +29,7 @@ final class SyncRecordMapper {
             DateFormat format = new SimpleDateFormat(SQLiteSyncConfig.DATE_FORMAT);
             if (colValue != null && !colValue.isEmpty()) {
                 try {
-                    if(colValue.trim().length() == 10)
+                    if (colValue.trim().length() == 10)
                         colValue += " 00:00:00";
                     Date date = format.parse(colValue);
                     record.put(columnName, format.format(date));

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -113,8 +113,8 @@ public class SyncService {
 
         stopwatch.stop();
         Long stopwatchMilisecs  = stopwatch.elapsed(TimeUnit.MILLISECONDS);
-        if(stopwatchMilisecs > 400)
-            if(dataToSync.get(0).RowsCount.isEmpty())
+        if (stopwatchMilisecs > 400)
+            if (dataToSync.get(0).RowsCount.isEmpty())
                 Logs.write(Logs.Level.WARN, "Getting changes for subscriber ["+deviceUUID+"]/[" + subscriberId + "] and table [" + tableName + "], no changes. Time elapsed: "+ stopwatchMilisecs);
             else
                 Logs.write(Logs.Level.WARN, "Getting changes for subscriber ["+deviceUUID+"]/[" + subscriberId + "] and table [" + tableName + "], records count [" + dataToSync.get(0).RowsCount + "/" + dataToSync.get(0).MaxPackageSize + "]. Time elapsed: "+ stopwatchMilisecs);
@@ -562,7 +562,7 @@ public class SyncService {
             if (!skipRowId || !fieldName.equalsIgnoreCase(SQLQueries.GET_ROWID_COLUMN_NAME())) {
                 DatabaseTableParameter param = getParamForDbField(fieldName, paramList);
                 if (param != null)
-                    ParseStatementParameter(statement, param.ParameterOrder,
+                    parseStatementParameter(statement, param.ParameterOrder,
                             fieldName, value.asText(), param);
             }
         }
@@ -596,7 +596,7 @@ public class SyncService {
         }
     }
 
-    private void ParseStatementParameter(PreparedStatement insertStatement, Integer colNumber, String colName, String colValue, Object paramDef) {
+    private void parseStatementParameter(PreparedStatement insertStatement, Integer colNumber, String colName, String colValue, Object paramDef) {
 
         if (colValue == null || colValue.equalsIgnoreCase("null"))
             colValue = "";
@@ -837,16 +837,15 @@ public class SyncService {
                     break;
             }
         } catch (SQLException | ParseException e) {
-            String recieveDataStatmentDesc = insertStatement.toString();
-            Logs.write(Logs.Level.INFO, "ParseStatmentParameter()->" +colName +", ["+recieveDataStatmentDesc+"] ," + e.getMessage());
+            String receivedDataStatementDesc = insertStatement.toString();
+            Logs.write(Logs.Level.INFO, "parseStatementParameter()->" + colName + ", [" + receivedDataStatementDesc + "] ," + e.getMessage());
         }
     }
 
     private void setDefaultsForParams(PreparedStatement insertStatement, String currentTable, List<DatabaseTableParameter> paramList) {
-        for(DatabaseTableParameter parameter: paramList)
-        {
+        for (DatabaseTableParameter parameter : paramList) {
             DatabaseTableParameter param = getParamForDbField(parameter.ParameterName, paramList);
-            ParseStatementParameter(insertStatement, param.ParameterOrder,  parameter.ParameterName, null, param);
+            parseStatementParameter(insertStatement, param.ParameterOrder, parameter.ParameterName, null, param);
         }
     }
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionRepository.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionRepository.java
@@ -9,7 +9,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-public class SyncSessionRepository {
+final class SyncSessionRepository {
     private final SQLQueries QUERIES = new SQLQueries();
 
     public Integer startSync(String subscriberId, Integer tableId, String schema) {

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionRepository.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionRepository.java
@@ -12,7 +12,7 @@ import java.sql.Statement;
 final class SyncSessionRepository {
     private final SQLQueries QUERIES = new SQLQueries();
 
-    public Integer startSync(String subscriberId, Integer tableId, String schema) {
+    Integer startSync(String subscriberId, Integer tableId, String schema) {
         Connection cn = Database.getInstance().GetDBConnection();
         try {
             Integer id = 0;
@@ -46,7 +46,7 @@ final class SyncSessionRepository {
         return 0;
     }
 
-    public void finishSync(String syncId, String schema) {
+    void finishSync(String syncId, String schema) {
         Connection cn = Database.getInstance().GetDBConnection();
         try {
             PreparedStatement query = cn.prepareStatement(QUERIES.COMMIT_SYNC_UPDATE(schema));

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
@@ -4,7 +4,7 @@ import com.ampliapps.amplisync.SQLiteSyncConfig;
 
 import javax.sql.rowset.CachedRowSet;
 
-public class SyncSessionStore {
+final class SyncSessionStore {
 
     public void writeSyncData(String syncId, CachedRowSet inserts, CachedRowSet updates, CachedRowSet deletes) {
         BinaryWriter binaryWriter = binaryWriter();

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
@@ -6,22 +6,22 @@ import javax.sql.rowset.CachedRowSet;
 
 final class SyncSessionStore {
 
-    public void writeSyncData(String syncId, CachedRowSet inserts, CachedRowSet updates, CachedRowSet deletes) {
+    void writeSyncData(String syncId, CachedRowSet inserts, CachedRowSet updates, CachedRowSet deletes) {
         BinaryWriter binaryWriter = binaryWriter();
         binaryWriter.writeToBinary(syncDataFile(syncId), inserts);
         binaryWriter.writeToBinary(syncDataUpdatesFile(syncId), updates);
         binaryWriter.writeToBinary(syncDataDeletesFile(syncId), deletes);
     }
 
-    public CachedRowSet readInserts(String syncId) {
+    CachedRowSet readInserts(String syncId) {
         return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataFile(syncId));
     }
 
-    public CachedRowSet readUpdates(String syncId) {
+    CachedRowSet readUpdates(String syncId) {
         return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataUpdatesFile(syncId));
     }
 
-    public CachedRowSet readDeletes(String syncId) {
+    CachedRowSet readDeletes(String syncId) {
         return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataDeletesFile(syncId));
     }
 


### PR DESCRIPTION
## Summary

Cleans up visibility and formatting in synchronization helper classes after the main flow refactors.

 ## Changes

- Made synchronization helper classes package-private, or final,  where appropriate.
- Narrowed helper method visibility where possible.
- Tidied formatting in synchronization helper files.
- Removed unnecessary public specifiers,  from  helper mehods
- No  business logic changes.
- 
 ## Testing

- Regression sync tests pass locally.