### PR TITLE
Bugfix/receive delete table validation

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
@@ -87,8 +87,20 @@ public class SyncAPI3 {
             @HeaderParam("Dev-User-Id") String devUserId) {
         String subscriberUUID = getSubscriberUUID(token, devUserId);
         SyncService sync = new SyncService();
-        sync.ReceiveData(receivedData, UserSchemaGuavaCacheUtil.getUserSchemaUsingGuava(subscriberUUID), subscriberUUID, deviceUniqueId);
-        return Response.ok().build();
+
+        try {
+            sync.ReceiveData(
+                    receivedData,
+                    UserSchemaGuavaCacheUtil.getUserSchemaUsingGuava(subscriberUUID),
+                    subscriberUUID,
+                    deviceUniqueId
+            );
+            return Response.ok().build();
+        } catch (InvalidReceivePayloadException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(e.getMessage())
+                    .build();
+        }
     }
 
     @GET

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
@@ -97,7 +97,7 @@ public class SyncAPI3 {
             );
             return Response.ok().build();
         } catch (InvalidReceivePayloadException e) {
-            return Response.status(Response.Status.BAD_REQUEST)
+            return Response.status(Response.Status.FORBIDDEN)
                     .entity(e.getMessage())
                     .build();
         }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/InvalidReceivePayloadException.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/InvalidReceivePayloadException.java
@@ -1,0 +1,7 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+public class InvalidReceivePayloadException extends RuntimeException {
+    public InvalidReceivePayloadException(String message) {
+        super(message);
+    }
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -418,9 +418,13 @@ public class SyncService {
                 for (String tableName : orderedTableList)
                     commitTableChanges(changes, tableName, schema, subscriberId);
             }
+        } catch (InvalidReceivePayloadException e) {
+            Logs.write(Logs.Level.ERROR, "CommitChangesToDb() " + e.getMessage());
+            throw e;
         } catch (Exception e) {
             Logs.write(Logs.Level.ERROR, "CommitChangesToDb() " + e.getMessage());
-        } finally {
+        }
+        finally {
             JDBCCloser.close(cn);
         }
     }
@@ -568,7 +572,7 @@ public class SyncService {
         }
     }
 
-    private void pushDeletedRecords(JsonNode deletes, String schema) {
+    private void pushDeletedRecords(JsonNode deletes, String schema) throws SQLException {
         Connection cn = Database.getInstance().GetDBConnection();
         try {
             if (deletes.isArray()) {
@@ -576,8 +580,6 @@ public class SyncService {
                     pushDeletedRecord(cn, node, schema);
                 }
             }
-        } catch (Exception e) {
-            Logs.write(Logs.Level.ERROR, "PushDeletedRecords() " + e.getMessage());
         } finally {
             JDBCCloser.close(cn);
         }
@@ -589,13 +591,9 @@ public class SyncService {
 
         String deleteQuery = "delete from " + schema + "." + tableName + " where rowid = ?";
 
-        try {
-            PreparedStatement deleteStatement = cn.prepareStatement(deleteQuery);
-            deleteStatement.setString(1, rowId);
-            deleteStatement.executeUpdate();
-        } catch (SQLException e) {
-            Logs.write(Logs.Level.ERROR, "PushDeletedRecords() " + e.getMessage());
-        }
+        PreparedStatement deleteStatement = cn.prepareStatement(deleteQuery);
+        deleteStatement.setString(1, rowId);
+        deleteStatement.executeUpdate();
     }
 
     private String requireSyncedTable(Connection cn, String schema, String
@@ -610,8 +608,9 @@ public class SyncService {
             return resultSet.getString("tablename");
         }
 
-        throw new SQLException("Table is not configured for sync: " + schema + "."
-                + tableName);
+        throw new InvalidReceivePayloadException(
+                "Table is not configured for sync: " + schema + "." + tableName
+        );
     }
 
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -583,9 +583,10 @@ public class SyncService {
         }
     }
 
-    private void pushDeletedRecord(Connection cn, JsonNode node, String schema) {
+    private void pushDeletedRecord(Connection cn, JsonNode node, String schema) throws SQLException {
         String rowId = node.path("rowid").asText();
-        String tableName = node.path("table").asText();
+        String tableName = requireSyncedTable(cn, schema, node.path("table").asText());
+
         String deleteQuery = "delete from " + schema + "." + tableName + " where rowid = ?";
 
         try {
@@ -596,6 +597,23 @@ public class SyncService {
             Logs.write(Logs.Level.ERROR, "PushDeletedRecords() " + e.getMessage());
         }
     }
+
+    private String requireSyncedTable(Connection cn, String schema, String
+            tableName) throws SQLException {
+        PreparedStatement statement =
+                cn.prepareStatement(QUERIES.DO_SYNC_GET_TABLE(schema));
+        statement.setString(1, tableName);
+        statement.setString(2, schema);
+
+        ResultSet resultSet = statement.executeQuery();
+        if (resultSet.next()) {
+            return resultSet.getString("tablename");
+        }
+
+        throw new SQLException("Table is not configured for sync: " + schema + "."
+                + tableName);
+    }
+
 
     private void parseStatementParameter(
             PreparedStatement statement,

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -584,13 +584,14 @@ public class SyncService {
     }
 
     private void pushDeletedRecord(Connection cn, JsonNode node, String schema) {
-        String rowid = node.path("rowid").asText();
-        String tableId = node.path("table").asText();
-        String deleteQuery = "delete from " + schema + "." + tableId + " where rowid='" + rowid + "'";
+        String rowId = node.path("rowid").asText();
+        String tableName = node.path("table").asText();
+        String deleteQuery = "delete from " + schema + "." + tableName + " where rowid = ?";
 
         try {
-            Statement deleteStatement = cn.createStatement();
-            deleteStatement.executeUpdate(deleteQuery);
+            PreparedStatement deleteStatement = cn.prepareStatement(deleteQuery);
+            deleteStatement.setString(1, rowId);
+            deleteStatement.executeUpdate();
         } catch (SQLException e) {
             Logs.write(Logs.Level.ERROR, "PushDeletedRecords() " + e.getMessage());
         }

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -106,6 +106,15 @@ public class SyncDevClient {
     }
 
     public void sendChanges(String deviceId, PushPayload payload) {
+        int statusCode = sendChangesAndReturnStatus(deviceId, payload);
+
+        if (statusCode < 200 || statusCode >= 300) {
+            throw new IllegalStateException("Send changes failed with status: " +
+                    statusCode);
+        }
+    }
+
+    public int sendChangesAndReturnStatus(String deviceId, PushPayload payload) {
         if (deviceId == null || deviceId.isBlank()) {
             throw new IllegalArgumentException("deviceId can't be empty");
         }
@@ -114,20 +123,20 @@ public class SyncDevClient {
         try {
             json = objectMapper.writeValueAsString(payload);
         } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Failed to serialize push payload", e);
+            throw new IllegalStateException("Failed to serialize push payload",
+                    e);
         }
 
-        HttpRequest request = requestBuilder(syncBaseUrl + "receive-changes/" + deviceId)
+        HttpRequest request = requestBuilder(syncBaseUrl + "receive-changes/" +
+                deviceId)
                 .header("Content-Type", "application/json")
                 .POST(HttpRequest.BodyPublishers.ofString(json))
                 .build();
 
         try {
-            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                throw new IllegalStateException("Send changes failed with status: " + response.statusCode());
-            }
+            HttpResponse<String> response = httpClient.send(request,
+                    HttpResponse.BodyHandlers.ofString());
+            return response.statusCode();
         } catch (IOException e) {
             throw new IllegalStateException("Send changes request failed", e);
         } catch (InterruptedException e) {

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.nio.file.Path;
 import java.io.File;
 import java.util.Map;
+import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Testcontainers
@@ -389,8 +390,64 @@ class SyncDeviceRegressionTest {
         }
     }
 
+    @Test
+    void shouldNotTreatReceiveDeleteRowIdAsSql() {
+        SyncDevClient client = createClient(DEV_USER_ID);
+        String testRunId = newId();
 
+        try (SyncDevice deviceA = createDevice(client, testRunId, "device-a");
+             SyncDevice deviceB = createDevice(client, testRunId, "device-b"))
+        {
+            deviceA.prepopulate();
+            deviceB.prepopulate();
 
+            String customerId = newId();
+            Map<String, Object> customer = customer(
+                    customerId,
+                    "SQL Injection Customer",
+                    "sql-injection@example.com",
+                    "Warsaw"
+            );
+
+            deviceA.insertRow(DemoCustomersFixture.TABLE, customer);
+            deviceA.push();
+            deviceA.pullTable(DemoCustomersFixture.TABLE);
+            deviceB.pullTable(DemoCustomersFixture.TABLE);
+
+            String rowId = deviceA.findFirstValue(
+                    DemoCustomersFixture.TABLE,
+                    "rowid",
+                    "id",
+                    customerId
+            );
+
+            PayloadBuilder.PushPayload maliciousPayload = new
+                    PayloadBuilder.PushPayload(
+                    List.of(),
+                    List.of(new DeletedRecord(
+                            DemoCustomersFixture.TABLE,
+                            rowId + "' OR true --"
+                    ))
+            );
+
+            int statusCode = client.sendChangesAndReturnStatus(
+                    testRunId + "-device-a",
+                    maliciousPayload
+            );
+
+            assertEquals(200, statusCode);
+
+            deviceB.pullTable(DemoCustomersFixture.TABLE);
+
+            SyncDeviceAssertions.assertRowValues(
+                    deviceB,
+                    DemoCustomersFixture.TABLE,
+                    "id",
+                    customerId,
+                    customer
+            );
+        }
+    }
 
 
     private static Map<String, Object> customer(String id, String name, String email, String city) {

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -465,7 +465,7 @@ class SyncDeviceRegressionTest {
 
             int statusCode = client.sendChangesAndReturnStatus(deviceId, payload);
 
-            assertEquals(400, statusCode);
+            assertEquals(403, statusCode);
         }
     }
 

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -449,6 +449,26 @@ class SyncDeviceRegressionTest {
         }
     }
 
+    @Test
+    void shouldRejectReceiveDeleteForTableOutsideSyncConfiguration() {
+        SyncDevClient client = createClient(DEV_USER_ID);
+        String testRunId = newId();
+        String deviceId = testRunId + "-device-a";
+
+        try (SyncDevice deviceA = createDevice(client, testRunId, "device-a")) {
+            deviceA.prepopulate();
+
+            PayloadBuilder.PushPayload payload = new PayloadBuilder.PushPayload(
+                    List.of(),
+                    List.of(new DeletedRecord("mergesubscribers", newId()))
+            );
+
+            int statusCode = client.sendChangesAndReturnStatus(deviceId, payload);
+
+            assertEquals(400, statusCode);
+        }
+    }
+
 
     private static Map<String, Object> customer(String id, String name, String email, String city) {
         return Map.of(


### PR DESCRIPTION
## Summary

Fixes receive delete handling so client-provided delete payloads cannot directly control SQL execution.

`rowid` is now bound through `PreparedStatement`, and the table name from the payload is validated against the sync table configuration before being used in the delete query.

## Changes

- Changed receive delete SQL to bind `rowid` as a JDBC parameter.
- Added validation that rejects deletes for tables outside sync configuration.
- Added `InvalidReceivePayloadException` for invalid receive payloads.
- Mapped invalid receive payloads to `400 Bad Request` in `receive-changes`.
- Added dev-client support for checking receive response status.
- Added regression tests for:
  - SQL injection attempt through `rowid`,
  - delete payload targeting a table outside sync configuration.

## Testing

- Regression sync tests pass locally.
