### PR TITLE
Bugfix/syncdata schema namespace

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -156,7 +156,7 @@ public class SyncService {
 
         Integer syncId = syncSessionRepository.startSync(subscriberId, tableId, schema);
 
-        syncSessionStore.writeSyncData(syncId.toString(), inserts, updates, deletes);
+        syncSessionStore.writeSyncData(schema, syncId.toString(), inserts, updates, deletes);
 
         return syncId;
     }
@@ -235,9 +235,9 @@ public class SyncService {
     }
 
     public void CommitSync(String syncId, String schema) {
-        CachedRowSet cachedDataInserts = syncSessionStore.readInserts(syncId);
-        CachedRowSet cachedDataUpdates = syncSessionStore.readUpdates(syncId);
-        CachedRowSet cachedDataDeletes = syncSessionStore.readDeletes(syncId);
+        CachedRowSet cachedDataInserts = syncSessionStore.readInserts(schema, syncId);
+        CachedRowSet cachedDataUpdates = syncSessionStore.readUpdates(schema, syncId);
+        CachedRowSet cachedDataDeletes = syncSessionStore.readDeletes(schema, syncId);
 
         CommitSyncSession session = readCommitSyncSession(syncId, schema);
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
@@ -1,43 +1,57 @@
 package com.ampliapps.amplisync.SyncServer.Synchronization;
 
 import com.ampliapps.amplisync.SQLiteSyncConfig;
+import java.io.File;
+
 
 import javax.sql.rowset.CachedRowSet;
 
 final class SyncSessionStore {
 
-    void writeSyncData(String syncId, CachedRowSet inserts, CachedRowSet updates, CachedRowSet deletes) {
+    void writeSyncData(String schema, String syncId, CachedRowSet inserts, CachedRowSet updates, CachedRowSet deletes) {
+
+        ensureSyncDataDirectoryExists(schema);
+
         BinaryWriter binaryWriter = binaryWriter();
-        binaryWriter.writeToBinary(syncDataFile(syncId), inserts);
-        binaryWriter.writeToBinary(syncDataUpdatesFile(syncId), updates);
-        binaryWriter.writeToBinary(syncDataDeletesFile(syncId), deletes);
+        binaryWriter.writeToBinary(syncDataFile(schema, syncId), inserts);
+        binaryWriter.writeToBinary(syncDataUpdatesFile(schema, syncId), updates);
+        binaryWriter.writeToBinary(syncDataDeletesFile(schema, syncId), deletes);
+
     }
 
-    CachedRowSet readInserts(String syncId) {
-        return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataFile(syncId));
+    CachedRowSet readInserts(String syncId, String schema) {
+        return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataFile(schema, syncId));
     }
 
-    CachedRowSet readUpdates(String syncId) {
-        return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataUpdatesFile(syncId));
+    CachedRowSet readUpdates(String syncId, String schema) {
+        return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataUpdatesFile(schema, syncId));
     }
 
-    CachedRowSet readDeletes(String syncId) {
-        return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataDeletesFile(syncId));
+    CachedRowSet readDeletes(String syncId, String schema) {
+        return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataDeletesFile(schema, syncId));
     }
 
     private BinaryWriter binaryWriter() {
         return new BinaryWriter();
     }
 
-    private String syncDataFile(String syncId) {
-        return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + ".dat";
+    private void ensureSyncDataDirectoryExists(String schema) {
+        File directory = new File(SQLiteSyncConfig.WORKING_DIR + "SyncData/" + schema);
+        if (!directory.exists()) {
+            directory.mkdirs();
+        }
     }
 
-    private String syncDataUpdatesFile(String syncId) {
-        return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + "_updates.dat";
+    private String syncDataFile(String schema, String syncId) {
+        return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + schema + "/" + syncId + ".dat";
     }
 
-    private String syncDataDeletesFile(String syncId) {
-        return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + syncId + "_deletes.dat";
+    private String syncDataUpdatesFile(String schema, String syncId) {
+        return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + schema + "/" + syncId + "_updates.dat";
     }
+
+    private String syncDataDeletesFile(String schema, String syncId) {
+        return SQLiteSyncConfig.WORKING_DIR + "SyncData/" + schema + "/" + syncId + "_deletes.dat";
+    }
+
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionStore.java
@@ -19,15 +19,15 @@ final class SyncSessionStore {
 
     }
 
-    CachedRowSet readInserts(String syncId, String schema) {
+    CachedRowSet readInserts(String schema, String syncId) {
         return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataFile(schema, syncId));
     }
 
-    CachedRowSet readUpdates(String syncId, String schema) {
+    CachedRowSet readUpdates(String schema, String syncId) {
         return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataUpdatesFile(schema, syncId));
     }
 
-    CachedRowSet readDeletes(String syncId, String schema) {
+    CachedRowSet readDeletes(String schema, String syncId) {
         return (CachedRowSet) binaryWriter().readFromBinaryFile(syncDataDeletesFile(schema, syncId));
     }
 


### PR DESCRIPTION
## Summary

Fixes `SyncData` collisions by storing sync session files, in schema-specific directory.

Previously, sync session files were named only by `syncId`, for example `SyncData/1.dat`. Since `syncId` is generated inside `{schema}.mergesync`, the same `syncId` can exist in different schemas. This could cause one schema's pull session data to overwrite another schema's files.

## Changes

- Store sync session files under `SyncData/{schema}/`.
- Read commit-sync session files from the same schema-specific path.
- Keep the existing file format and sync behavior unchanged.

## Testing

- Regression sync tests pass locally.
- I did not add a new regression test for the multi tenant collision  yet - it requires modifying  the dev test database,  with at least a second tenant with its own schema, so that two schemas can create the same `syncId`.