### PR TITLE
Bugfix/reject missing commit sync session

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
@@ -67,14 +67,23 @@ public class SyncAPI3 {
             @HeaderParam(HttpHeaders.AUTHORIZATION) String token,
             @HeaderParam("Dev-User-Id") String devUserId) {
 
-        Response response = Response.ok().build();
-        if(syncId.isEmpty() || syncId == null)
-            return response;
+        if (syncId == null || syncId.isEmpty())
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("Sync session id is required")
+                    .build();
+
         String subscriberUUID = getSubscriberUUID(token, devUserId);
         String schema = UserSchemaGuavaCacheUtil.getUserSchemaUsingGuava(subscriberUUID);
         SyncService sync = new SyncService();
-        sync.CommitSync(syncId, schema);
-        return response;
+
+        try {
+            sync.CommitSync(syncId, schema);
+            return Response.ok().build();
+        } catch (InvalidCommitSyncSessionException e) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity(e.getMessage())
+                    .build();
+        }
     }
 
     @POST

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/InvalidCommitSyncSessionException.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/InvalidCommitSyncSessionException.java
@@ -1,0 +1,7 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+public class InvalidCommitSyncSessionException extends RuntimeException {
+    public InvalidCommitSyncSessionException(String message) {
+        super(message);
+    }
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -250,18 +250,17 @@ public class SyncService {
     }
 
     private CommitSyncSession readCommitSyncSession(String syncId, String schema) {
-        String tableName = "";
-        int subscriberId = 0;
-
         Connection cn = Database.getInstance().GetDBConnection();
         try {
             PreparedStatement query = cn.prepareStatement(QUERIES.COMMIT_SYNC(schema));
             query.setInt(1, Integer.parseInt(syncId));
             ResultSet reader = query.executeQuery();
 
-            while (reader.next()) {
-                tableName = reader.getString("TableName");
-                subscriberId = reader.getInt("subscriberId");
+            if (reader.next()) {
+                return new CommitSyncSession(
+                        reader.getString("TableName"),
+                        reader.getInt("subscriberId")
+                );
             }
         } catch (SQLException e) {
             Logs.write(Logs.Level.ERROR, "CommitSync() " + e.getMessage());
@@ -269,7 +268,7 @@ public class SyncService {
             JDBCCloser.close(cn);
         }
 
-        return new CommitSyncSession(tableName, subscriberId);
+        throw new InvalidCommitSyncSessionException("Sync session was not found: " + syncId);
     }
 
     private void updateSyncData(

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -182,16 +182,21 @@ public class SyncDevClient {
             return;
         }
 
+        int statusCode = commitSyncAndReturnStatus(syncId);
+
+        if (statusCode < 200 || statusCode >= 300) {
+            throw new IllegalStateException("Commit sync failed with status: " + statusCode);
+        }
+    }
+
+    public int commitSyncAndReturnStatus(int syncId) {
         HttpRequest request = requestBuilder(syncBaseUrl + "commit-sync/" + syncId)
                 .GET()
                 .build();
 
         try {
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
-
-            if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                throw new IllegalStateException("Commit sync failed with status: " + response.statusCode());
-            }
+            return response.statusCode();
         } catch (IOException e) {
             throw new IllegalStateException("Commit sync request failed", e);
         } catch (InterruptedException e) {

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -469,6 +469,14 @@ class SyncDeviceRegressionTest {
         }
     }
 
+    @Test
+    void shouldReturnNotFoundForMissingCommitSyncSession() {
+        SyncDevClient client = createClient(DEV_USER_ID);
+
+        int statusCode = client.commitSyncAndReturnStatus(Integer.MAX_VALUE);
+
+        assertEquals(404, statusCode);
+    }
 
     private static Map<String, Object> customer(String id, String name, String email, String city) {
         return Map.of(


### PR DESCRIPTION
## Summary

Fixes `commit-sync` so it no longer returns success for a missing sync session.

Previously, if `/commit-sync/{syncId}` was called with a `syncId` that did not exist, `readCommitSyncSession()` returned default values (`tableName = ""`, `subscriberId = 0`) and the flow continued. Now the session fails,  and the API returns 404

  ## Changes

- Added exception for invalid commit-sync sessions.
- Changed `readCommitSyncSession()` to fail when no session is found.
- Mapped invalid commit-sync sessions to `404 Not Found` in `SyncAPI3`.
- Added a dev-client regression test for a missing commit-sync session.

## Notes

  There are similar error-handling patterns in other sync flows. examples: 
  - file  errors while reading or writing in session stores, are logged but not propagated further
  - some sync endpoints can still return `200 ` even if operations failed.

  ## Testing

  - Regression sync tests 
