### PR TITLE
fix 1 - reject failed receive records

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Helpers.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Helpers.java
@@ -75,6 +75,8 @@ public class Helpers {
                 SQLiteType = "TEXT";
                 break;
             case "timestamp":
+            case "timestamp without time zone":
+            case "timestamp with time zone":
             case "datetime2":
             case "datetime":
                 SQLiteType = "DATETIME";

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/SchemaPublish/SchemaGenerator.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/SchemaPublish/SchemaGenerator.java
@@ -209,6 +209,11 @@ public class SchemaGenerator {
             case "REAL":
                 defaultValue = "DEFAULT (" + column.DefaultValue + ")";
                 break;
+            case "DATE":
+            case "DATETIME":
+                defaultValue = "DEFAULT (" + column.DefaultValue + ")";
+                break;
+
         }
         return defaultValue;
     }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/DatabaseTable.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/DatabaseTable.java
@@ -58,6 +58,10 @@ public class DatabaseTable {
                 if(column.DefaultValue != null && column.DefaultValue.equalsIgnoreCase("CURRENT_DATE"))
                     column.DefaultValue = "datetime('now', 'localtime')";
 
+                if (column.DefaultValue != null && column.DefaultValue.equalsIgnoreCase("CURRENT_TIMESTAMP"))
+                    column.DefaultValue = "datetime('now', 'localtime')";
+
+
                 if(column.DefaultValue != null && column.DefaultValue.equalsIgnoreCase("uuid_generate_v4()"))
                     column.DefaultValue = "";
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -860,7 +860,11 @@ public class SyncService {
         } catch (SQLException | ParseException e) {
             String receivedDataStatementDesc = statement.toString();
             Logs.write(Logs.Level.INFO, "parseStatementParameter()->" + columnName + ", [" + receivedDataStatementDesc + "] ," + e.getMessage());
+            throw new InvalidReceivePayloadException(
+                    "Invalid value for column " + columnName + ": " + e.getMessage()
+            );
         }
+
     }
 
     private boolean isEmptyStatementValue(String value) {

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -857,15 +857,19 @@ public class SyncService {
                     statement.setString(parameterIndex, columnValue);
                     break;
             }
-        } catch (SQLException | ParseException e) {
-            String receivedDataStatementDesc = statement.toString();
-            Logs.write(Logs.Level.INFO, "parseStatementParameter()->" + columnName + ", [" + receivedDataStatementDesc + "] ," + e.getMessage());
-            throw new InvalidReceivePayloadException(
-                    "Invalid value for column " + columnName + ": " + e.getMessage()
-            );
-        }
-
+        } catch (ParseException e) {
+        String receivedDataStatementDesc = statement.toString();
+        Logs.write(Logs.Level.INFO, "parseStatementParameter()->" + columnName + ", [" + receivedDataStatementDesc + "] ," + e.getMessage());
+        throw new InvalidReceivePayloadException(
+                "Invalid value for column " + columnName + ": " + e.getMessage()
+        );
+    } catch (SQLException e) {
+        String receivedDataStatementDesc = statement.toString();
+        Logs.write(Logs.Level.INFO, "parseStatementParameter()->" + columnName + ", [" + receivedDataStatementDesc + "] ," + e.getMessage());
     }
+
+
+}
 
     private boolean isEmptyStatementValue(String value) {
         return value == null || value.isEmpty();

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -405,6 +405,8 @@ public class SyncService {
     private void commitChangesToDb(ObjectNode data, String schema, String subscriberId) {
         Connection cn = Database.getInstance().GetDBConnection();
         try {
+            validateReceivePayload(cn, data, schema);
+
             Logs.write(Logs.Level.DEBUG, "CommitChangesToDb(). Started collecting deleted records.");
             JsonNode deletes = data.path("deletes");
             pushDeletedRecords(deletes, schema);
@@ -440,6 +442,60 @@ public class SyncService {
                 Logs.write(Logs.Level.DEBUG, "CommitChangesToDb(). Started collecting updates.");
                 pushUpdateRecords(updates, tableName, schema);
                 Logs.write(Logs.Level.DEBUG, "CommitChangesToDb(). Finished collecting updates.");
+            }
+        }
+    }
+
+    private void validateReceivePayload(Connection cn, ObjectNode data, String schema) throws SQLException {
+        validateDeletedRecords(cn, data.path("deletes"), schema);
+
+        JsonNode changes = data.path("changes");
+        if (changes.isArray()) {
+            for (JsonNode change : changes) {
+                String tableName = change.path("table").asText();
+                String syncedTableName = requireSyncedTable(cn, schema, tableName);
+
+                validateInsertRecords(cn, change.path("inserts"), syncedTableName, schema);
+                validateUpdateRecords(cn, change.path("updates"), syncedTableName, schema);
+            }
+        }
+    }
+
+    private void validateDeletedRecords(Connection cn, JsonNode deletes, String schema) throws SQLException {
+        if (deletes.isArray()) {
+            for (JsonNode node : deletes) {
+                String tableName = node.path("table").asText();
+                requireSyncedTable(cn, schema, tableName);
+            }
+        }
+    }
+
+    private void validateInsertRecords(Connection cn, JsonNode inserts, String tableName, String schema) throws SQLException {
+        SchemaGenerator schemaGen = new SchemaGenerator();
+        String insertSQLQuery = schemaGen.CreateInsertStatementWithParams(tableName, schema);
+        List<DatabaseTableParameter> paramList = schemaGen.GetStatmentParams(tableName, true, schema, 1);
+
+        try (PreparedStatement statement = cn.prepareStatement(insertSQLQuery)) {
+            setDefaultsForParams(statement, tableName, paramList);
+
+            if (inserts.isArray()) {
+                for (JsonNode node : inserts) {
+                    bindJsonFieldsToStatement(node, statement, paramList, true);
+                }
+            }
+        }
+    }
+
+    private void validateUpdateRecords(Connection cn, JsonNode updates, String tableName, String schema) throws SQLException {
+        SchemaGenerator schemaGen = new SchemaGenerator();
+        String updateSQLQuery = schemaGen.CreateUpdateStatmentWithParams(tableName, schema);
+        List<DatabaseTableParameter> paramList = schemaGen.GetStatmentParams(tableName, false, schema, 2);
+
+        try (PreparedStatement statement = cn.prepareStatement(updateSQLQuery)) {
+            if (updates.isArray()) {
+                for (JsonNode node : updates) {
+                    bindJsonFieldsToStatement(node, statement, paramList, false);
+                }
             }
         }
     }
@@ -595,8 +651,7 @@ public class SyncService {
         deleteStatement.executeUpdate();
     }
 
-    private String requireSyncedTable(Connection cn, String schema, String
-            tableName) throws SQLException {
+    private String requireSyncedTable(Connection cn, String schema, String tableName) throws SQLException {
         PreparedStatement statement =
                 cn.prepareStatement(QUERIES.DO_SYNC_GET_TABLE(schema));
         statement.setString(1, tableName);

--- a/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
+++ b/tools/dev-client/src/main/java/com/ampliapps/amplisync/devclient/SyncDevClient.java
@@ -136,6 +136,11 @@ public class SyncDevClient {
         try {
             HttpResponse<String> response = httpClient.send(request,
                     HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() >= 400) {
+                System.out.println("receive-changes failed with status " + response.statusCode());
+                System.out.println(response.body());
+            }
+
             return response.statusCode();
         } catch (IOException e) {
             throw new IllegalStateException("Send changes request failed", e);
@@ -143,6 +148,8 @@ public class SyncDevClient {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Send changes request was interrupted", e);
         }
+
+
     }
 
     public List<PullChanges> pullChangesForTable(String tableName, String deviceId) {

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -508,6 +508,71 @@ class SyncDeviceRegressionTest {
         assertEquals(404, statusCode);
     }
 
+    @Test
+    void shouldRejectInvalidReceivePayloadBeforeApplyingDeletes() {
+        SyncDevClient client = createClient(DEV_USER_ID);
+        String testRunId = newId();
+
+        try (SyncDevice deviceA = createDevice(client, testRunId, "device-a");
+             SyncDevice deviceB = createDevice(client, testRunId, "device-b")) {
+            deviceA.prepopulate();
+            deviceB.prepopulate();
+
+            String customerId = newId();
+            Map<String, Object> customer = customer(
+                    customerId,
+                    "Validation Customer",
+                    "validation@example.com",
+                    "Warsaw"
+            );
+
+            deviceA.insertRow(DemoCustomersFixture.TABLE, customer);
+            deviceA.push();
+            deviceA.pullTable(DemoCustomersFixture.TABLE);
+            deviceB.pullTable(DemoCustomersFixture.TABLE);
+
+            String rowId = deviceA.findFirstValue(
+                    DemoCustomersFixture.TABLE,
+                    "rowid",
+                    "id",
+                    customerId
+            );
+
+            PayloadBuilder.PushPayload payload = new PayloadBuilder.PushPayload(
+                    List.of(new TableChanges(
+                            DemoCustomersFixture.TABLE,
+                            List.of(Map.of(
+                                    "id", newId(),
+                                    "name", "Invalid Date Customer",
+                                    "email", "invalid-date@example.com",
+                                    "city", "Warsaw",
+                                    "created_at", "invalidtimestamp"
+                            )),
+                            List.of()
+                    )),
+                    List.of(new DeletedRecord(DemoCustomersFixture.TABLE, rowId))
+            );
+
+            int statusCode = client.sendChangesAndReturnStatus(
+                    testRunId + "-device-a",
+                    payload
+            );
+
+            assertEquals(403, statusCode);
+
+            deviceB.pullTable(DemoCustomersFixture.TABLE);
+
+            SyncDeviceAssertions.assertRowValues(
+                    deviceB,
+                    DemoCustomersFixture.TABLE,
+                    "id",
+                    customerId,
+                    customer
+            );
+        }
+    }
+
+
     private static Map<String, Object> customer(String id, String name, String email, String city) {
         return Map.of(
                 "id", id,

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -470,6 +470,36 @@ class SyncDeviceRegressionTest {
     }
 
     @Test
+    void shouldRejectReceiveInsertWithInvalidTimestampValue() {
+        SyncDevClient client = createClient(DEV_USER_ID);
+        String testRunId = newId();
+        String deviceId = testRunId + "-device-a";
+
+        try (SyncDevice deviceA = createDevice(client, testRunId, "device-a")) {
+            deviceA.prepopulate();
+
+            PayloadBuilder.PushPayload payload = new PayloadBuilder.PushPayload(
+                    List.of(new TableChanges(
+                            DemoCustomersFixture.TABLE,
+                            List.of(Map.of(
+                                    "id", newId(),
+                                    "name", "Invalid Timestamp ",
+                                    "email", "invalidtimestamp@example.com",
+                                    "city", "Warsaw",
+                                    "created_at", "invalidtimestamp"
+                            )),
+                            List.of()
+                    )),
+                    List.of()
+            );
+
+            int statusCode = client.sendChangesAndReturnStatus(deviceId, payload);
+
+            assertEquals(403, statusCode);
+        }
+    }
+
+    @Test
     void shouldReturnNotFoundForMissingCommitSyncSession() {
         SyncDevClient client = createClient(DEV_USER_ID);
 


### PR DESCRIPTION
 
## Summary

This PR started as a fix for receive flow exception handling, but handling exceptions exposed issue with dates and timestamps.

Before this change, date parsing errors in receive payloads were only logged and then ignored, so the backend could continue  the request even when one of the values could not be parsed correctly.

  After changing that behavior to return an error for invalid date values, regression tests exposed another issue: generated SQLite schemas could save `CURRENT_TIMESTAMP` as a literal text value. So a normal sync payload could contain `"CURRENT_TIMESTAMP"` instead of an actual timestamp, and the new validation correctly rejected it.

The schema generation issue had two parts. First, PostgreSQL can expose timestamp columns as types like `timestamp without time zone`, and those were not mapped to SQLite `DATETIME`.
  Second, even when a column type was already mapped to `DATETIME` or `DATE`, default values for those SQLite types were not generated. Because of that, timestamp/date defaults were either missing or generated incorrectly.


## Changes

  - Invalid date/timestamp values in receive payload now stop receive processing.
  - `InvalidReceivePayloadException` is propagated to `SyncAPI3`.
  - `SyncAPI3` returns an error response with the reason in the body.
  - `SQLException` handling is left unchanged for now.
 - Fixed generated SQLite timestamp/date defaults:
   - maps PostgreSQL `timestamp without time zone` / `timestamp with time zone` to SQLite `DATETIME`,
   - converts `CURRENT_TIMESTAMP` to a real SQLite datetime expression instead of plain text,
   - adds default value generation for SQLite `DATE` / `DATETIME`.

   Added regression test for invalid timestamp values.

## Testing

- Regression sync tests passed