### PR TITLE
fix 3 - receive insert retry

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/SchemaPublish/SchemaGenerator.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/SchemaPublish/SchemaGenerator.java
@@ -283,7 +283,7 @@ public class SchemaGenerator {
         tmp = insert.toString().substring(0, insert.toString().length() - 1);
         insert = new StringBuilder();
         insert.append(tmp);
-        insert.append(";");
+        insert.append(" returning rowid;");
         return insert.toString().toLowerCase();
     }
 

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -511,13 +511,22 @@ public class SyncService {
             insertStatement.setString(param.ParameterOrder, rowIdValue);
             insertStatement.execute();
 
-            mergeContent.setInt(1, Integer.parseInt(subscriber));
-            mergeContent.setString(2, rowIdValue);
-            mergeContent.setTimestamp(3, new java.sql.Timestamp(new Date().getTime()));
-            mergeContent.setInt(4, 1);
-            mergeContent.setInt(5, 0);
-            mergeContent.setBoolean(6, true);
-            mergeContent.execute();
+            try (ResultSet result = insertStatement.executeQuery()) {
+                if (!result.next()) {
+                    throw new SQLException("Receive insert did not return rowid");
+                }
+
+                String persistedRowId = result.getString("rowid");
+
+                mergeContent.setInt(1, Integer.parseInt(subscriber));
+                mergeContent.setString(2, persistedRowId);
+                mergeContent.setTimestamp(3, new java.sql.Timestamp(new Date().getTime()));
+                mergeContent.setInt(4, 1);
+                mergeContent.setInt(5, 0);
+                mergeContent.setBoolean(6, true);
+                mergeContent.execute();
+            }
+
         } catch (SQLException e) {
             Logs.write(Logs.Level.ERROR, "PushInsertRecords()->Execute insert: " +
                     e.getMessage() + "; " + insertStatement);

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -509,7 +509,6 @@ public class SyncService {
             DatabaseTableParameter param =
                     getParamForDbField(SQLQueries.GET_ROWID_COLUMN_NAME(), paramList);
             insertStatement.setString(param.ParameterOrder, rowIdValue);
-            insertStatement.execute();
 
             try (ResultSet result = insertStatement.executeQuery()) {
                 if (!result.next()) {

--- a/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
+++ b/tools/dev-client/src/test/java/com/ampliapps/amplisync/devclient/SyncDeviceRegressionTest.java
@@ -487,6 +487,47 @@ class SyncDeviceRegressionTest {
         );
     }
 
+    @Test
+    void shouldNotReturnDeleteForRetriedInsert() {
+        SyncDevClient client = createClient(DEV_USER_ID);
+        String testRunId = newId();
+
+        try (SyncDevice deviceA = createDevice(client, testRunId, "device-a")) {
+            deviceA.prepopulate();
+
+            String customerId = newId();
+            Map<String, Object> customer = customer(
+                    customerId,
+                    "Retried Insert Customer",
+                    "retried-insert@example.com",
+                    "Warsaw"
+            );
+
+            PayloadBuilder.PushPayload payload = new PayloadBuilder.PushPayload(
+                    List.of(new TableChanges(
+                            DemoCustomersFixture.TABLE,
+                            List.of(customer),
+                            List.of()
+                    )),
+                    List.of()
+            );
+
+            client.sendChanges(deviceA.deviceId(), payload);
+            client.sendChanges(deviceA.deviceId(), payload);
+
+            List<Map<String, Object>> deletes = client.pullChangesForTable(
+                            DemoCustomersFixture.TABLE,
+                            deviceA.deviceId()
+                    )
+                    .stream()
+                    .filter(change -> change.records() != null)
+                    .flatMap(change -> change.records().deletes().stream())
+                    .toList();
+
+            assertTrue(deletes.isEmpty(), deletes.toString());
+        }
+    }
+
     private static String newId() {
         return UUID.randomUUID().toString();
     }


### PR DESCRIPTION
## Summary

 This PR fixes a bug found while testing receive insert retries.

How bug was found: after sending the same insert payload twice, the next pull could return a `delete`, even though no delete was sent by the client. That delete contained a `rowid` that the client never had locally.


The cause was in receive insert handling. Before this change, `pushInsertRecord()` generated a new `rowid` before every insert:

```java
  String rowIdValue = UUID.randomUUID().toString();
  insertStatement.setString(param.ParameterOrder, rowIdValue);
  insertStatement.execute();
```
The insert SQL uses:

```
ON CONFLICT (id) DO UPDATE
```

So when the same insert was retried, PostgreSQL updated the existing row by id. But the update part does not update rowid, so the real row kept its original rowid.

The bug was that mergecontent was still written with the newly generated Java value:
`mergeContent.setString(2, rowIdValue);`

That left `mergecontent` pointing to a rowid that does not exist in the actual table. Later, pull thought, that  that empty mergecontent entry was a deleted row and returned it in deletes.


## Changes

  - Added `RETURNING rowid` to receive insert  SQL.
  - Use the `rowid` returned by PostgreSQL when writing `mergecontent`.
  - Added a regression test that sends the same insert twice and verifies pull does not return a false delete.

## Testing

- Regression sync tests pass locally.

## Notes

remaining existing problem is that `mergecontent` now can contain duplicate rows for the same `(subscriberid, rowid)`, because that pair is indexed, but not unique. This PRoes not solve that  issue; it only prevents retries from creating `mergecontent` rows for non-existing rowids, and that caused false deletes during pull.


