### PR TITLE
fix 4 - sync session file errors 

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncAPI3.java
@@ -52,6 +52,10 @@ public class SyncAPI3 {
             outStream.close();
             byte[] compressedBytes = baostream.toByteArray();
             return Response.ok(compressedBytes, MediaType.APPLICATION_OCTET_STREAM).build();
+        } catch (SyncSessionFileException e) {
+            return Response.serverError()
+                    .entity(e.getMessage())
+                    .build();
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         } catch (IOException e) {
@@ -81,6 +85,10 @@ public class SyncAPI3 {
             return Response.ok().build();
         } catch (InvalidCommitSyncSessionException e) {
             return Response.status(Response.Status.NOT_FOUND)
+                    .entity(e.getMessage())
+                    .build();
+        } catch (SyncSessionFileException e) {
+            return Response.serverError()
                     .entity(e.getMessage())
                     .build();
         }
@@ -121,11 +129,17 @@ public class SyncAPI3 {
             @HeaderParam("Dev-User-Id") String devUserId) {
 
         String subscriberUUID = getSubscriberUUID(token, devUserId);
-        SQLitePrepopulate sqLitePrepopulate = new SQLitePrepopulate();
-        File file = new File(sqLitePrepopulate.PrepopulateDatabase(subscriberUUID, deviceUniqueId));
-        return Response.ok(file, MediaType.APPLICATION_OCTET_STREAM)
-                .header("Content-Disposition", "attachment; filename=\"" + file.getName() + "\"")
-                .build();
+        try {
+            SQLitePrepopulate sqLitePrepopulate = new SQLitePrepopulate();
+            File file = new File(sqLitePrepopulate.PrepopulateDatabase(subscriberUUID, deviceUniqueId));
+            return Response.ok(file, MediaType.APPLICATION_OCTET_STREAM)
+                    .header("Content-Disposition", "attachment; filename=\"" + file.getName() + "\"")
+                    .build();
+        } catch (SyncSessionFileException e) {
+            return Response.serverError()
+                    .entity(e.getMessage())
+                    .build();
+        }
     }
 
     /// Helpers

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/BinaryWriter.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/BinaryWriter.java
@@ -3,53 +3,34 @@ package com.ampliapps.amplisync.SyncServer.Synchronization;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.OutputStream;
 
 public class BinaryWriter {
 
     public void writeToBinary(String filename, Object obj) {
-        File file = new File(filename);
-        ObjectOutputStream out = null;
-        Boolean append = false;
-
-        try {
-            out = new ObjectOutputStream(new FileOutputStream(filename));
+        try (ObjectOutputStream out = new ObjectOutputStream(new FileOutputStream(filename))) {
             out.writeObject(obj);
             out.flush();
         } catch (Exception e) {
-            e.printStackTrace();
-        } finally {
-            try {
-                if (out != null) out.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            throw new SyncSessionFileException("Could not write sync session file: " + filename, e);
         }
     }
+
 
     public Object readFromBinaryFile(String filename) {
         File file = new File(filename);
 
-        if (file.exists()) {
-            ObjectInputStream ois = null;
-            try {
-                ois = new ObjectInputStream(new FileInputStream(filename));
-                while (true) {
-                    return ois.readObject();
-                }
-            } catch (Exception e) {
-                e.printStackTrace();
-            } finally {
-                try {
-                    if (ois != null) ois.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
+        if (!file.exists()) {
+            return null;
         }
-        return null;
+
+        try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(filename))) {
+            return ois.readObject();
+        } catch (Exception e) {
+            throw new SyncSessionFileException("Could not read sync session file: " + filename, e);
+        }
     }
+
+
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionFileException.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionFileException.java
@@ -1,0 +1,7 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+public class SyncSessionFileException extends RuntimeException {
+    public SyncSessionFileException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes swallowed errors when reading or writing sync session files.

Before this change, `BinaryWriter` only printed stack traces when a `.dat` file could not be written or read. The sync flow could then continue as if the file operation succeeded, which could lead to a false success.

## Changes

- Added `SyncSessionFileException`.
- Changed `BinaryWriter` to throw when session file read/write fails.
- Mapped sync session file errors to  `500` responses in sync endpoints 
- Cleaned up `BinaryWriter` a bit:
  - replaced manual stream closing with try-with-resources,
  - removed unused variables,
  - removed the unnecessary `while (true)` around a single `readObject()` return.

## Testing

- Regression sync tests pass locally.
