### PR TITLE
Refactor/1 commit sync service

### DIFF
--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
@@ -1,13 +1,6 @@
-package com.ampliapps.amplisync.SyncServer.Synchronization;
-
-import com.ampliapps.amplisync.JDBCCloser;
-import com.ampliapps.amplisync.Logs;
+package com.ampliapps.amplisync.SyncServer.Synchronization;;
 
 import javax.sql.rowset.CachedRowSet;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 
 final class CommitSyncService {
     private final SQLQueries QUERIES = new SQLQueries();
@@ -15,15 +8,12 @@ final class CommitSyncService {
     private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
     private final MergeContentRepository mergeContentRepository = new MergeContentRepository();
 
-    private record CommitSyncSession(String tableName, int subscriberId) {
-    }
-
     void commit(String syncId, String schema) {
         CachedRowSet cachedDataInserts = syncSessionStore.readInserts(schema, syncId);
         CachedRowSet cachedDataUpdates = syncSessionStore.readUpdates(schema, syncId);
         CachedRowSet cachedDataDeletes = syncSessionStore.readDeletes(schema, syncId);
 
-        CommitSyncSession session = readCommitSyncSession(syncId, schema);
+        CommitSyncSession session = syncSessionRepository.readCommitSyncSession(syncId, schema);
 
         mergeContentRepository.updateInsertedSyncData(
                 Integer.parseInt(syncId),
@@ -51,26 +41,5 @@ final class CommitSyncService {
 
     }
 
-    private CommitSyncSession readCommitSyncSession(String syncId, String schema) {
-        Connection cn = Database.getInstance().GetDBConnection();
-        try {
-            PreparedStatement query = cn.prepareStatement(QUERIES.COMMIT_SYNC(schema));
-            query.setInt(1, Integer.parseInt(syncId));
-            ResultSet reader = query.executeQuery();
-
-            if (reader.next()) {
-                return new CommitSyncSession(
-                        reader.getString("TableName"),
-                        reader.getInt("subscriberId")
-                );
-            }
-        } catch (SQLException e) {
-            Logs.write(Logs.Level.ERROR, "CommitSync() " + e.getMessage());
-        } finally {
-            JDBCCloser.close(cn);
-        }
-
-        throw new InvalidCommitSyncSessionException("Sync session was not found: " + syncId);
-    }
 
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
@@ -1,9 +1,8 @@
-package com.ampliapps.amplisync.SyncServer.Synchronization;;
+package com.ampliapps.amplisync.SyncServer.Synchronization;
 
 import javax.sql.rowset.CachedRowSet;
 
 final class CommitSyncService {
-    private final SQLQueries QUERIES = new SQLQueries();
     private final SyncSessionStore syncSessionStore = new SyncSessionStore();
     private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
     private final MergeContentRepository mergeContentRepository = new MergeContentRepository();

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
@@ -47,8 +47,5 @@ final class CommitSyncService {
         );
 
         syncSessionRepository.finishSync(syncId, schema);
-
     }
-
-
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
@@ -1,0 +1,134 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+import com.ampliapps.amplisync.JDBCCloser;
+import com.ampliapps.amplisync.Logs;
+
+import javax.sql.rowset.CachedRowSet;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Date;
+
+final class CommitSyncService {
+    private final SQLQueries QUERIES = new SQLQueries();
+    private final SyncSessionStore syncSessionStore = new SyncSessionStore();
+    private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
+
+    void commit(String syncId, String schema) {
+        CachedRowSet cachedDataInserts = syncSessionStore.readInserts(schema, syncId);
+        CachedRowSet cachedDataUpdates = syncSessionStore.readUpdates(schema, syncId);
+        CachedRowSet cachedDataDeletes = syncSessionStore.readDeletes(schema, syncId);
+
+        CommitSyncSession session = readCommitSyncSession(syncId, schema);
+
+        updateSyncData(Integer.parseInt(syncId), schema, session, cachedDataInserts, cachedDataUpdates, cachedDataDeletes);
+
+        syncSessionRepository.finishSync(syncId, schema);
+    }
+
+    private record CommitSyncSession(String tableName, int subscriberId) {
+    }
+
+    private CommitSyncSession readCommitSyncSession(String syncId, String schema) {
+        Connection cn = Database.getInstance().GetDBConnection();
+        try {
+            PreparedStatement query = cn.prepareStatement(QUERIES.COMMIT_SYNC(schema));
+            query.setInt(1, Integer.parseInt(syncId));
+            ResultSet reader = query.executeQuery();
+
+            if (reader.next()) {
+                return new CommitSyncSession(
+                        reader.getString("TableName"),
+                        reader.getInt("subscriberId")
+                );
+            }
+        } catch (SQLException e) {
+            Logs.write(Logs.Level.ERROR, "CommitSync() " + e.getMessage());
+        } finally {
+            JDBCCloser.close(cn);
+        }
+
+        throw new InvalidCommitSyncSessionException("Sync session was not found: " + syncId);
+    }
+
+    private void updateSyncData(
+            Integer syncId,
+            String schema,
+            CommitSyncSession session,
+            CachedRowSet cachedDataInserts,
+            CachedRowSet cachedDataUpdates,
+            CachedRowSet cachedDataDeletes
+    ) {
+        updateInsertedSyncData(syncId, schema, session, cachedDataInserts);
+        updateUpdatedSyncData(schema, session, cachedDataUpdates);
+        updateDeletedSyncData(schema, session, cachedDataDeletes);
+    }
+
+    private void updateInsertedSyncData(Integer syncId, String schema, CommitSyncSession session, CachedRowSet cachedDataInserts) {
+        if (cachedDataInserts != null) {
+            Connection cn = Database.getInstance().GetDBConnection();
+            try {
+                PreparedStatement cmdI = cn.prepareStatement(QUERIES.INSERT_MERGE_CONTENT(schema, session.tableName()));
+                cachedDataInserts.beforeFirst();
+                while (cachedDataInserts.next()) {
+                    cmdI.setInt(1, session.subscriberId());
+                    cmdI.setString(2, cachedDataInserts.getString("rowid").trim());
+                    cmdI.setTimestamp(3, new java.sql.Timestamp(new Date().getTime()));
+                    cmdI.setInt(4, 1);
+                    cmdI.setInt(5, syncId);
+                    cmdI.setBoolean(6, false);
+                    cmdI.addBatch();
+                }
+                cmdI.executeBatch();
+            } catch (Exception e) {
+                Logs.write(Logs.Level.ERROR, "UpdateSyncData() " + e.getMessage());
+            } finally {
+                JDBCCloser.close(cn);
+            }
+        }
+    }
+
+    private void updateUpdatedSyncData(String schema, CommitSyncSession session, CachedRowSet cachedDataUpdates) {
+        if (cachedDataUpdates != null) {
+            Connection cn = Database.getInstance().GetDBConnection();
+            try {
+                PreparedStatement cmdU = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_UPDATE(schema, session.tableName()));
+
+                cachedDataUpdates.beforeFirst();
+                while (cachedDataUpdates.next()) {
+                    cmdU.setString(1, cachedDataUpdates.getString("rowid").trim());
+                    cmdU.setInt(2, session.subscriberId());
+                    cmdU.addBatch();
+                }
+                cmdU.executeBatch();
+
+            } catch (Exception e) {
+                Logs.write(Logs.Level.ERROR, "UpdateSyncData()->updates " + e.getMessage());
+            } finally {
+                JDBCCloser.close(cn);
+            }
+        }
+    }
+
+    private void updateDeletedSyncData(String schema, CommitSyncSession session, CachedRowSet cachedDataDeletes) {
+        if (cachedDataDeletes != null) {
+            Connection cn = Database.getInstance().GetDBConnection();
+            try {
+                PreparedStatement cmdD = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_DELETE(schema, session.tableName()));
+                cachedDataDeletes.beforeFirst();
+                while (cachedDataDeletes.next()) {
+                    cmdD.setString(1, cachedDataDeletes.getString(1));
+                    cmdD.setInt(2, session.subscriberId());
+                    cmdD.addBatch();
+                }
+                cmdD.executeBatch();
+
+            } catch (Exception e) {
+                Logs.write(Logs.Level.ERROR, "UpdateSyncData()->deletes " + e.getMessage());
+            } finally {
+                JDBCCloser.close(cn);
+            }
+        }
+    }
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
@@ -8,12 +8,15 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Date;
 
 final class CommitSyncService {
     private final SQLQueries QUERIES = new SQLQueries();
     private final SyncSessionStore syncSessionStore = new SyncSessionStore();
     private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
+    private final MergeContentRepository mergeContentRepository = new MergeContentRepository();
+
+    private record CommitSyncSession(String tableName, int subscriberId) {
+    }
 
     void commit(String syncId, String schema) {
         CachedRowSet cachedDataInserts = syncSessionStore.readInserts(schema, syncId);
@@ -22,12 +25,30 @@ final class CommitSyncService {
 
         CommitSyncSession session = readCommitSyncSession(syncId, schema);
 
-        updateSyncData(Integer.parseInt(syncId), schema, session, cachedDataInserts, cachedDataUpdates, cachedDataDeletes);
+        mergeContentRepository.updateInsertedSyncData(
+                Integer.parseInt(syncId),
+                schema,
+                session.tableName(),
+                session.subscriberId(),
+                cachedDataInserts
+        );
+
+        mergeContentRepository.updateUpdatedSyncData(
+                schema,
+                session.tableName(),
+                session.subscriberId(),
+                cachedDataUpdates
+        );
+
+        mergeContentRepository.updateDeletedSyncData(
+                schema,
+                session.tableName(),
+                session.subscriberId(),
+                cachedDataDeletes
+        );
 
         syncSessionRepository.finishSync(syncId, schema);
-    }
 
-    private record CommitSyncSession(String tableName, int subscriberId) {
     }
 
     private CommitSyncSession readCommitSyncSession(String syncId, String schema) {
@@ -52,83 +73,4 @@ final class CommitSyncService {
         throw new InvalidCommitSyncSessionException("Sync session was not found: " + syncId);
     }
 
-    private void updateSyncData(
-            Integer syncId,
-            String schema,
-            CommitSyncSession session,
-            CachedRowSet cachedDataInserts,
-            CachedRowSet cachedDataUpdates,
-            CachedRowSet cachedDataDeletes
-    ) {
-        updateInsertedSyncData(syncId, schema, session, cachedDataInserts);
-        updateUpdatedSyncData(schema, session, cachedDataUpdates);
-        updateDeletedSyncData(schema, session, cachedDataDeletes);
-    }
-
-    private void updateInsertedSyncData(Integer syncId, String schema, CommitSyncSession session, CachedRowSet cachedDataInserts) {
-        if (cachedDataInserts != null) {
-            Connection cn = Database.getInstance().GetDBConnection();
-            try {
-                PreparedStatement cmdI = cn.prepareStatement(QUERIES.INSERT_MERGE_CONTENT(schema, session.tableName()));
-                cachedDataInserts.beforeFirst();
-                while (cachedDataInserts.next()) {
-                    cmdI.setInt(1, session.subscriberId());
-                    cmdI.setString(2, cachedDataInserts.getString("rowid").trim());
-                    cmdI.setTimestamp(3, new java.sql.Timestamp(new Date().getTime()));
-                    cmdI.setInt(4, 1);
-                    cmdI.setInt(5, syncId);
-                    cmdI.setBoolean(6, false);
-                    cmdI.addBatch();
-                }
-                cmdI.executeBatch();
-            } catch (Exception e) {
-                Logs.write(Logs.Level.ERROR, "UpdateSyncData() " + e.getMessage());
-            } finally {
-                JDBCCloser.close(cn);
-            }
-        }
-    }
-
-    private void updateUpdatedSyncData(String schema, CommitSyncSession session, CachedRowSet cachedDataUpdates) {
-        if (cachedDataUpdates != null) {
-            Connection cn = Database.getInstance().GetDBConnection();
-            try {
-                PreparedStatement cmdU = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_UPDATE(schema, session.tableName()));
-
-                cachedDataUpdates.beforeFirst();
-                while (cachedDataUpdates.next()) {
-                    cmdU.setString(1, cachedDataUpdates.getString("rowid").trim());
-                    cmdU.setInt(2, session.subscriberId());
-                    cmdU.addBatch();
-                }
-                cmdU.executeBatch();
-
-            } catch (Exception e) {
-                Logs.write(Logs.Level.ERROR, "UpdateSyncData()->updates " + e.getMessage());
-            } finally {
-                JDBCCloser.close(cn);
-            }
-        }
-    }
-
-    private void updateDeletedSyncData(String schema, CommitSyncSession session, CachedRowSet cachedDataDeletes) {
-        if (cachedDataDeletes != null) {
-            Connection cn = Database.getInstance().GetDBConnection();
-            try {
-                PreparedStatement cmdD = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_DELETE(schema, session.tableName()));
-                cachedDataDeletes.beforeFirst();
-                while (cachedDataDeletes.next()) {
-                    cmdD.setString(1, cachedDataDeletes.getString(1));
-                    cmdD.setInt(2, session.subscriberId());
-                    cmdD.addBatch();
-                }
-                cmdD.executeBatch();
-
-            } catch (Exception e) {
-                Logs.write(Logs.Level.ERROR, "UpdateSyncData()->deletes " + e.getMessage());
-            } finally {
-                JDBCCloser.close(cn);
-            }
-        }
-    }
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncService.java
@@ -3,9 +3,19 @@ package com.ampliapps.amplisync.SyncServer.Synchronization;
 import javax.sql.rowset.CachedRowSet;
 
 final class CommitSyncService {
-    private final SyncSessionStore syncSessionStore = new SyncSessionStore();
-    private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
-    private final MergeContentRepository mergeContentRepository = new MergeContentRepository();
+    private final SyncSessionStore syncSessionStore;
+    private final SyncSessionRepository syncSessionRepository;
+    private final MergeContentRepository mergeContentRepository;
+
+    CommitSyncService(
+            SyncSessionStore syncSessionStore,
+            SyncSessionRepository syncSessionRepository,
+            MergeContentRepository mergeContentRepository
+    ) {
+        this.syncSessionStore = syncSessionStore;
+        this.syncSessionRepository = syncSessionRepository;
+        this.mergeContentRepository = mergeContentRepository;
+    }
 
     void commit(String syncId, String schema) {
         CachedRowSet cachedDataInserts = syncSessionStore.readInserts(schema, syncId);

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncSession.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/CommitSyncSession.java
@@ -1,0 +1,4 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+record CommitSyncSession(String tableName, int subscriberId) {
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/MergeContentRepository.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/MergeContentRepository.java
@@ -1,0 +1,96 @@
+package com.ampliapps.amplisync.SyncServer.Synchronization;
+
+import com.ampliapps.amplisync.JDBCCloser;
+import com.ampliapps.amplisync.Logs;
+
+import javax.sql.rowset.CachedRowSet;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.Date;
+
+final class MergeContentRepository {
+    private final SQLQueries QUERIES = new SQLQueries();
+
+    void updateInsertedSyncData(
+            Integer syncId,
+            String schema,
+            String tableName,
+            int subscriberId,
+            CachedRowSet cachedDataInserts
+    ) {
+        if (cachedDataInserts != null) {
+            Connection cn = Database.getInstance().GetDBConnection();
+            try {
+                PreparedStatement cmdI = cn.prepareStatement(QUERIES.INSERT_MERGE_CONTENT(schema, tableName));
+                cachedDataInserts.beforeFirst();
+                while (cachedDataInserts.next()) {
+                    cmdI.setInt(1, subscriberId);
+                    cmdI.setString(2, cachedDataInserts.getString("rowid").trim());
+                    cmdI.setTimestamp(3, new java.sql.Timestamp(new Date().getTime()));
+                    cmdI.setInt(4, 1);
+                    cmdI.setInt(5, syncId);
+                    cmdI.setBoolean(6, false);
+                    cmdI.addBatch();
+                }
+                cmdI.executeBatch();
+            } catch (Exception e) {
+                Logs.write(Logs.Level.ERROR, "UpdateSyncData() " + e.getMessage());
+            } finally {
+                JDBCCloser.close(cn);
+            }
+        }
+    }
+
+    void updateUpdatedSyncData(
+            String schema,
+            String tableName,
+            int subscriberId,
+            CachedRowSet cachedDataUpdates
+    ) {
+        if (cachedDataUpdates != null) {
+            Connection cn = Database.getInstance().GetDBConnection();
+            try {
+                PreparedStatement cmdU = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_UPDATE(schema, tableName));
+
+                cachedDataUpdates.beforeFirst();
+                while (cachedDataUpdates.next()) {
+                    cmdU.setString(1, cachedDataUpdates.getString("rowid").trim());
+                    cmdU.setInt(2, subscriberId);
+                    cmdU.addBatch();
+                }
+                cmdU.executeBatch();
+
+            } catch (Exception e) {
+                Logs.write(Logs.Level.ERROR, "UpdateSyncData()->updates " + e.getMessage());
+            } finally {
+                JDBCCloser.close(cn);
+            }
+        }
+    }
+
+    void updateDeletedSyncData(
+            String schema,
+            String tableName,
+            int subscriberId,
+            CachedRowSet cachedDataDeletes
+    ) {
+        if (cachedDataDeletes != null) {
+            Connection cn = Database.getInstance().GetDBConnection();
+            try {
+                PreparedStatement cmdD = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_DELETE(schema, tableName));
+                cachedDataDeletes.beforeFirst();
+                while (cachedDataDeletes.next()) {
+                    cmdD.setString(1, cachedDataDeletes.getString(1));
+                    cmdD.setInt(2, subscriberId);
+                    cmdD.addBatch();
+                }
+                cmdD.executeBatch();
+
+            } catch (Exception e) {
+                Logs.write(Logs.Level.ERROR, "UpdateSyncData()->deletes " + e.getMessage());
+            } finally {
+                JDBCCloser.close(cn);
+            }
+        }
+    }
+}

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -37,6 +37,7 @@ public class SyncService {
     private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
     private final SQLiteClientQueryBuilder sqLiteClientQueryBuilder = new SQLiteClientQueryBuilder();
     private final PullChangeEnumerator pullChangeEnumerator = new PullChangeEnumerator();
+    private final CommitSyncService commitSyncService = new CommitSyncService();
 
     public SyncService() {
         SQLiteSyncConfig.Load();
@@ -235,121 +236,7 @@ public class SyncService {
     }
 
     public void CommitSync(String syncId, String schema) {
-        CachedRowSet cachedDataInserts = syncSessionStore.readInserts(schema, syncId);
-        CachedRowSet cachedDataUpdates = syncSessionStore.readUpdates(schema, syncId);
-        CachedRowSet cachedDataDeletes = syncSessionStore.readDeletes(schema, syncId);
-
-        CommitSyncSession session = readCommitSyncSession(syncId, schema);
-
-        updateSyncData(Integer.parseInt(syncId), schema, session, cachedDataInserts, cachedDataUpdates, cachedDataDeletes);
-
-        syncSessionRepository.finishSync(syncId, schema);
-    }
-
-    private record CommitSyncSession(String tableName, int subscriberId) {
-    }
-
-    private CommitSyncSession readCommitSyncSession(String syncId, String schema) {
-        Connection cn = Database.getInstance().GetDBConnection();
-        try {
-            PreparedStatement query = cn.prepareStatement(QUERIES.COMMIT_SYNC(schema));
-            query.setInt(1, Integer.parseInt(syncId));
-            ResultSet reader = query.executeQuery();
-
-            if (reader.next()) {
-                return new CommitSyncSession(
-                        reader.getString("TableName"),
-                        reader.getInt("subscriberId")
-                );
-            }
-        } catch (SQLException e) {
-            Logs.write(Logs.Level.ERROR, "CommitSync() " + e.getMessage());
-        } finally {
-            JDBCCloser.close(cn);
-        }
-
-        throw new InvalidCommitSyncSessionException("Sync session was not found: " + syncId);
-    }
-
-    private void updateSyncData(
-            Integer syncId,
-            String schema,
-            CommitSyncSession session,
-            CachedRowSet cachedDataInserts,
-            CachedRowSet cachedDataUpdates,
-            CachedRowSet cachedDataDeletes
-    ) {
-        updateInsertedSyncData(syncId, schema, session, cachedDataInserts);
-        updateUpdatedSyncData(schema, session, cachedDataUpdates);
-        updateDeletedSyncData(schema, session, cachedDataDeletes);
-    }
-
-    private void updateInsertedSyncData(Integer syncId, String schema, CommitSyncSession session, CachedRowSet cachedDataInserts) {
-        if (cachedDataInserts != null) {
-            Connection cn = Database.getInstance().GetDBConnection();
-            try {
-                PreparedStatement cmdI = cn.prepareStatement(QUERIES.INSERT_MERGE_CONTENT(schema, session.tableName()));
-                cachedDataInserts.beforeFirst();
-                while (cachedDataInserts.next()) {
-                    cmdI.setInt(1, session.subscriberId());
-                    cmdI.setString(2, cachedDataInserts.getString("rowid").trim());
-                    cmdI.setTimestamp(3, new java.sql.Timestamp(new Date().getTime()));
-                    cmdI.setInt(4, 1);
-                    cmdI.setInt(5, syncId);
-                    cmdI.setBoolean(6, false);
-                    cmdI.addBatch();
-                }
-                cmdI.executeBatch();
-            } catch (Exception e) {
-                Logs.write(Logs.Level.ERROR, "UpdateSyncData() " + e.getMessage());
-            } finally {
-                JDBCCloser.close(cn);
-            }
-        }
-
-    }
-
-    private void updateUpdatedSyncData(String schema, CommitSyncSession session, CachedRowSet cachedDataUpdates) {
-        if (cachedDataUpdates != null) {
-            Connection cn = Database.getInstance().GetDBConnection();
-            try {
-                PreparedStatement cmdU = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_UPDATE(schema, session.tableName()));
-
-                cachedDataUpdates.beforeFirst();
-                while (cachedDataUpdates.next()) {
-                    cmdU.setString(1, cachedDataUpdates.getString("rowid").trim());
-                    cmdU.setInt(2, session.subscriberId());
-                    cmdU.addBatch();
-                }
-                cmdU.executeBatch();
-
-            } catch (Exception e) {
-                Logs.write(Logs.Level.ERROR, "UpdateSyncData()->updates " + e.getMessage());
-            } finally {
-                JDBCCloser.close(cn);
-            }
-        }
-    }
-
-    private void updateDeletedSyncData(String schema, CommitSyncSession session, CachedRowSet cachedDataDeletes) {
-        if (cachedDataDeletes != null) {
-            Connection cn = Database.getInstance().GetDBConnection();
-            try {
-                PreparedStatement cmdD = cn.prepareStatement(QUERIES.UPDATE_SYNC_DATA_DELETE(schema, session.tableName()));
-                cachedDataDeletes.beforeFirst();
-                while (cachedDataDeletes.next()) {
-                    cmdD.setString(1, cachedDataDeletes.getString(1));
-                    cmdD.setInt(2, session.subscriberId());
-                    cmdD.addBatch();
-                }
-                cmdD.executeBatch();
-
-            } catch (Exception e) {
-                Logs.write(Logs.Level.ERROR, "UpdateSyncData()->deletes " + e.getMessage());
-            } finally {
-                JDBCCloser.close(cn);
-            }
-        }
+        commitSyncService.commit(syncId, schema);
     }
 
     public void ReceiveData(ObjectNode receivedData, String schema, String subscriberUUID, String deviceUniqueId) {

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncService.java
@@ -33,11 +33,18 @@ public class SyncService {
     public Integer syncIdForTestPurpose = -1;
     private final SQLQueries QUERIES = new SQLQueries();
     private final PullQueryBuilder pullQueryBuilder = new PullQueryBuilder();
-    private final SyncSessionStore syncSessionStore = new SyncSessionStore();
-    private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
     private final SQLiteClientQueryBuilder sqLiteClientQueryBuilder = new SQLiteClientQueryBuilder();
     private final PullChangeEnumerator pullChangeEnumerator = new PullChangeEnumerator();
-    private final CommitSyncService commitSyncService = new CommitSyncService();
+
+    private final SyncSessionStore syncSessionStore = new SyncSessionStore();
+    private final MergeContentRepository mergeContentRepository = new MergeContentRepository();
+    private final SyncSessionRepository syncSessionRepository = new SyncSessionRepository();
+
+    private final CommitSyncService commitSyncService = new CommitSyncService(
+            syncSessionStore,
+            syncSessionRepository,
+            mergeContentRepository
+    );
 
     public SyncService() {
         SQLiteSyncConfig.Load();

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionRepository.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionRepository.java
@@ -58,4 +58,27 @@ final class SyncSessionRepository {
             JDBCCloser.close(cn);
         }
     }
+
+    CommitSyncSession readCommitSyncSession(String syncId, String schema) {
+        Connection cn = Database.getInstance().GetDBConnection();
+        try {
+            PreparedStatement query = cn.prepareStatement(QUERIES.COMMIT_SYNC(schema));
+            query.setInt(1, Integer.parseInt(syncId));
+            ResultSet reader = query.executeQuery();
+
+            if (reader.next()) {
+                return new CommitSyncSession(
+                        reader.getString("TableName"),
+                        reader.getInt("subscriberId")
+                );
+            }
+        } catch (SQLException e) {
+            Logs.write(Logs.Level.ERROR, "CommitSync() " + e.getMessage());
+        } finally {
+            JDBCCloser.close(cn);
+        }
+
+        throw new InvalidCommitSyncSessionException("Sync session was not found: " + syncId);
+    }
+
 }

--- a/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionRepository.java
+++ b/ampli-sync/src/main/java/com/ampliapps/amplisync/SyncServer/Synchronization/SyncSessionRepository.java
@@ -80,5 +80,4 @@ final class SyncSessionRepository {
 
         throw new InvalidCommitSyncSessionException("Sync session was not found: " + syncId);
     }
-
 }


### PR DESCRIPTION
## Summary

 This PR starts the second sync refactor by moving the `commit-sync` flow out of `SyncService`.

The goal is to begin splitting the large sync service into endpoint/use-case oriented services

## Changes

  - Added `CommitSyncService` for the `commit-sync` flow.
  - Kept `SyncService.CommitSync(...)` as a wrapper, so the API usage does not change.
  - Added `MergeContentRepository` for `mergecontent*` updates done during commit-sync.
  - Moved commit session lookup into `SyncSessionRepository`.
  - Added `CommitSyncSession` record
  - Injected `CommitSyncService` dependencies through the constructor,  instead of creating them inside the service.

## Notes

This is the first step of the larger architecture refactor. The direction is:

``text
SyncService -> endpoint/use-case services -> repositories/stores
``
No business logic changes.

## Testing

- Regression sync tests passed
